### PR TITLE
v0.5.13 — drop AT-SPI/ATK install steps and JRE bridge config (closes #1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,8 @@ Environment:
 - Architecture: amd64 / arm64
 - Trading mode: live / paper / both
 - Container image: (your image name + tag)
-- `USE_PYATSPI2_CONTROLLER`: yes
+- `USE_IBG_CONTROLLER`: yes  <!-- or USE_PYATSPI2_CONTROLLER if you're still on the deprecated alias -->
+
 - Other relevant env vars (redact credentials!):
 
 **Steps to reproduce**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,14 @@ jobs:
         run: make test
 
       - name: make release (build tarball)
-        run: make release VERSION=${GITHUB_REF_NAME#v}
+        # On tag pushes GITHUB_REF_NAME is e.g. "v0.5.13" → "0.5.13".
+        # On main pushes it's "main". On pull_request events it's
+        # "<num>/merge" — the slash leaks into the tarball path and
+        # breaks the glob in the next step, so squash any "/" to "-".
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          VERSION=${VERSION//\//-}
+          make release VERSION="$VERSION"
 
       - name: Verify tarball layout
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,14 @@ jobs:
   smoke-test-image:
     runs-on: ubuntu-24.04
     needs: build-and-test
-    # Smoke-test in a Docker container that mirrors the target
-    # runtime: Python 3 + pyatspi2 + ATK bridge. Verifies the module
-    # loads with the real gi stack (not just mocked sys.modules).
+    # Smoke-test in an environment that matches the shipped image's
+    # runtime layer: python3 plus the gi/Atspi typelib stack the
+    # controller still imports at module load (the AT-SPI runtime path
+    # was retired in v0.5.12 and the bridge install steps in v0.5.13,
+    # but `from gi.repository import Atspi` still happens during
+    # gateway_controller.py import). This catches `import` regressions
+    # against the real gi stack rather than the sys.modules mock the
+    # unit tests use.
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -117,7 +122,7 @@ jobs:
       - name: make
         run: make
 
-      - name: Real-pyatspi2 module-load smoke test
+      - name: Real-gi module-load smoke test
         env:
           TWS_USERID: x
           TWS_PASSWORD: x
@@ -128,6 +133,7 @@ jobs:
           sys.path.insert(0, ".")
           import gateway_controller as gc
           print("module loaded, version check OK")
+          print(f"  version={gc.__version__}")
           print(f"  TRADING_MODE={gc.TRADING_MODE}")
           print(f"  APP_NAME_CANDIDATES={gc.APP_NAME_CANDIDATES}")
           print(f"  SAFE_DISMISS_BUTTONS has {len(gc.SAFE_DISMISS_BUTTONS)} entries")
@@ -175,10 +181,10 @@ jobs:
             -t ibg-controller:matrix-test .
 
       - name: Container-level module-load smoke test
-        # Verify gateway_controller.py imports cleanly against the JRE +
-        # AT-SPI + ATK-bridge wiring inside the built image. Catches
-        # upstream base-image drift (missing libs, changed paths) at CI
-        # time rather than at runtime on a user's host.
+        # Verify gateway_controller.py imports cleanly inside the
+        # built image (python3 + gi + Atspi typelib). Catches upstream
+        # base-image drift (missing libs, changed paths) at CI time
+        # rather than at runtime on a user's host.
         env:
           TWS_USERID: x
           TWS_PASSWORD: x
@@ -190,10 +196,23 @@ jobs:
             ibg-controller:matrix-test \
             -c 'import sys; sys.path.insert(0, "/home/ibgateway/scripts"); import gateway_controller as gc; print(f"OK upstream={gc.__version__} TRADING_MODE={gc.TRADING_MODE}")'
 
-      - name: Verify ATK bridge wiring inside image
-        # accessibility.properties must be present in the Gateway JRE
-        # conf dir, and libatk-wrapper.so must live in the JRE lib dir.
-        # Checks both without starting Gateway itself.
+      - name: Verify AT-SPI bridge stays absent (regression guard)
+        # v0.5.13 removed the JRE accessibility.properties write and
+        # the libatk-wrapper.so copy into JAVA_HOME/lib (and the apt
+        # install of libatk-wrapper-java*). v0.5.12 disabled the
+        # bridge in the JVM after a thread-dump-confirmed deadlock —
+        # see CHANGELOG.md v0.5.12.
+        #
+        # This step guards against three regressions:
+        #   1. A future Dockerfile edit accidentally restoring the
+        #      accessibility.properties write or the .so copy.
+        #   2. The upstream gnzsnz/ib-gateway base image starting to
+        #      ship libatk-wrapper-java pre-installed (which would let
+        #      AtkWrapper load if the Java flag override were ever
+        #      removed).
+        #   3. The JVM-args-level disable
+        #      (-Djavax.accessibility.assistive_technologies=) being
+        #      stripped from gateway_controller.py.
         run: |
           docker run --rm --entrypoint bash ibg-controller:matrix-test -c '
             set -e
@@ -203,8 +222,45 @@ jobs:
             fi
             JAVA_HOME=$(dirname $(dirname "$GW_JAVA"))
             echo "JAVA_HOME=$JAVA_HOME"
-            test -f "$JAVA_HOME/conf/accessibility.properties" \
-              && echo "OK accessibility.properties present"
-            ls "$JAVA_HOME/lib/" | grep -q libatk-wrapper \
-              && echo "OK libatk-wrapper.so in JRE lib dir"
+
+            # 1. accessibility.properties must NOT have been written.
+            if [ -f "$JAVA_HOME/conf/accessibility.properties" ]; then
+              echo "REGRESSION: $JAVA_HOME/conf/accessibility.properties present —"
+              echo "v0.5.13 dropped this write. If the upstream base image now"
+              echo "ships its own copy, audit it before relaxing this guard."
+              cat "$JAVA_HOME/conf/accessibility.properties"
+              exit 1
+            fi
+            echo "OK accessibility.properties absent from JRE conf dir"
+
+            # 2. libatk-wrapper.so must NOT be in the JRE lib dir.
+            if ls "$JAVA_HOME/lib/" 2>/dev/null | grep -q libatk-wrapper; then
+              echo "REGRESSION: libatk-wrapper.so present in $JAVA_HOME/lib/ —"
+              echo "v0.5.13 dropped the JNI copy step. If the upstream base"
+              echo "now ships it, the AT-SPI bridge could load on a JVM that"
+              echo "does not have the assistive_technologies override."
+              exit 1
+            fi
+            echo "OK libatk-wrapper.so absent from JRE lib dir"
+
+            # 3. The JVM-args-level disable must still be in the controller.
+            #    (Belt-and-suspenders against base-image-shipped JARs.)
+            if ! grep -q -- "-Djavax.accessibility.assistive_technologies=" \
+                 /home/ibgateway/scripts/gateway_controller.py; then
+              echo "REGRESSION: gateway_controller.py no longer passes the"
+              echo "assistive_technologies disable flag — see v0.5.12 CHANGELOG"
+              echo "for the deadlock that motivated it."
+              exit 1
+            fi
+            echo "OK assistive_technologies disable flag still in controller"
+
+            # 4. Sanity: the things v0.5.13 KEPT must still be present.
+            test -f /home/ibgateway/gateway-input-agent.jar \
+              && echo "OK input agent jar in place"
+            test -f /home/ibgateway/scripts/gateway_controller.py \
+              && echo "OK controller python in place"
+            test -x /home/ibgateway/scripts/run.sh \
+              && echo "OK run.sh executable in place"
+            command -v matchbox-window-manager >/dev/null \
+              && echo "OK matchbox-window-manager installed"
           '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,76 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [0.5.13] - 2026-04-28
+
+### Removed
+
+- **AT-SPI / ATK install steps and JRE accessibility-bridge
+  configuration.** v0.5.12 disabled the bridge in the JVM after a
+  thread-dump-confirmed deadlock; v0.5.13 removes the now-vestigial
+  install steps the README and MIGRATION docs were still telling
+  users to add to their images.
+  - `Dockerfile`: drop `libatk-wrapper-java`, `libatk-wrapper-java-jni`,
+    `dbus-x11` from apt install. Drop the `RUN` block that writes
+    `$JAVA_HOME/conf/accessibility.properties` and copies
+    `libatk-wrapper.so` into `$JAVA_HOME/lib/`.
+  - `docker/run.sh`: drop `start_dbus_session` and `start_atspi`.
+    Drop the AT-SPI teardown branch in `stop_ibc`. The controller
+    still needs `start_window_manager` (matchbox) for Xvfb focus
+    routing — that stays.
+  - `gateway_controller.py`: drop the
+    `-Xbootclasspath/a:/usr/share/java/java-atk-wrapper.jar` JVM
+    arg (the JAR is no longer in the image).
+    `-Djavax.accessibility.assistive_technologies=` stays as
+    defense-in-depth in case a base image ships the JAR
+    pre-installed.
+- Image surface area for AT-SPI runtime infrastructure
+  (`at-spi-bus-launcher`, `at-spi2-registryd`, the `org.a11y.Bus`
+  D-Bus services) is no longer started. `python3-gi`,
+  `gir1.2-atspi-2.0`, and `at-spi2-core` remain installed because
+  `gateway_controller.py` still does
+  `from gi.repository import Atspi` at module load (the helper
+  functions that reference `Atspi.StateType.*` / `Atspi.Text.*` /
+  `Atspi.Action.*` have no live callers post-v0.5.12 but were not
+  physically removed in this release; that's a future cleanup).
+
+### Changed
+
+- **Env var rename, backwards compatible.**
+  `USE_PYATSPI2_CONTROLLER=yes` is renamed to `USE_IBG_CONTROLLER=yes`.
+  The old name is honored as a deprecated alias — `run.sh` checks for
+  it at startup and copies the value across, printing a one-line
+  warning. Existing `docker-compose.yml` files keep working without
+  modification. Rename at your leisure.
+- README, `docs/MIGRATION.md`, `docs/ARCHITECTURE.md`,
+  `docs/CONTRIBUTING.md`, `docs/UPGRADING.md`,
+  `docs/BOOTSTRAP.md`, `docs/FROM_IBC.md`, `scripts/install.sh`,
+  `Makefile`, and the `agent/GatewayInputAgent.java` javadoc were
+  rewritten to reflect post-v0.5.12 reality. Historical context
+  (the AT-SPI deadlock that motivated the change, the v0.5.12
+  triage signature, the spike findings about why external input
+  mechanisms fail) is preserved as labeled history.
+- `docs/ARCHITECTURE.md` collapses the four-section AT-SPI / D-Bus /
+  JRE-config block into a single historical-context callout. The
+  remaining "things that surprised us" entries about AT-SPI tree
+  staleness and the on-screen-keyboard `Action` interface are
+  retained as record of the 2026-Q1 spike.
+
+### Validation
+
+- `python3 -m py_compile gateway_controller.py` — OK.
+- `bash -n docker/run.sh` — OK.
+- Greps for `at.spi`, `atspi`, `ATK`, `atk-wrapper`, `pyatspi`,
+  `libatk`, `AtkWrapper`, `USE_PYATSPI2` across the repo show only
+  intentional historical mentions (CHANGELOG, post-mortem callouts)
+  or the deprecated-alias plumbing in `run.sh`.
+
+### Issue resolved
+
+- [#1](https://github.com/code-hustler-ft3d/ibg-controller/issues/1) —
+  README should no longer mention AT-SPI / ATK approach for the sake
+  of clarity.
+
 ## [0.5.12] - 2026-04-27
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make
 make install DESTDIR=/home/ibgateway
 
 # Create a release tarball
-make release VERSION=0.2.1
+make release VERSION=0.5.13
 ```
 
 Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.
@@ -22,15 +22,17 @@ Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.
 See `docs/ARCHITECTURE.md` for the full list and why each is needed.
 The short version:
 
-- `python3 python3-gi gir1.2-atspi-2.0` — Python AT-SPI2 bindings
-- `at-spi2-core` — provides `at-spi-bus-launcher` and `at-spi2-registryd`
-- `libatk-wrapper-java libatk-wrapper-java-jni` — bridges Swing ↔ AT-SPI
-- `dbus-x11` — for `dbus-launch`
-- `matchbox-window-manager` — Xvfb has no WM by default; synthetic
-  input routing needs a focus owner
-- The JRE needs `$JAVA_HOME/conf/accessibility.properties` pointing at
-  `org.GNOME.Accessibility.AtkWrapper`, and `libatk-wrapper.so` placed
-  at `$JAVA_HOME/lib/libatk-wrapper.so` (NOT on `LD_LIBRARY_PATH`)
+- `python3` — runs `gateway_controller.py`
+- `matchbox-window-manager` — Xvfb has no WM by default; Gateway's
+  input routing depends on a focused window
+
+Pre-v0.5.13 the image also installed `python3-gi gir1.2-atspi-2.0
+at-spi2-core libatk-wrapper-java libatk-wrapper-java-jni dbus-x11` and
+configured `$JAVA_HOME/conf/accessibility.properties`. v0.5.12 disabled
+the AT-SPI bridge in the JVM (it was deadlocking on Swing dispatch);
+v0.5.13 removed the install steps. If you're rebasing from an older
+fork, drop those packages and the JRE accessibility.properties write
+when you bring your image forward.
 
 ## Code layout
 
@@ -96,8 +98,9 @@ What this tool is NOT:
 - A trading framework
 
 If you want to use this outside Docker, it should mostly work — but
-the ATK bridge setup in your JRE and the AT-SPI session bus are the
-main things you'd need to replicate manually. See `docs/ARCHITECTURE.md`.
+you'll need an X display (Xvfb is the easy answer) and a window
+manager (matchbox is what the shipped image uses). See
+`docs/ARCHITECTURE.md`.
 
 ## Questions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 # ibg-controller image recipe.
 #
-# Extends a gnzsnz/ib-gateway base with the AT-SPI accessibility stack,
-# the Java ATK bridge, and the ibg-controller artifacts (agent jar +
-# Python controller). Swaps upstream's run.sh for the
-# USE_PYATSPI2_CONTROLLER=yes-aware variant shipped alongside.
+# Extends a gnzsnz/ib-gateway base with the ibg-controller artifacts
+# (agent jar + Python controller) and swaps upstream's run.sh for the
+# controller-aware variant shipped alongside.
 #
 # UPSTREAM_IMAGE defaults to the :stable moving tag for low-friction
 # local builds. Production consumers should pin a digest via --build-arg
@@ -21,45 +20,33 @@ FROM ${UPSTREAM_IMAGE}
 
 USER root
 
-# AT-SPI stack + matchbox WM. Matches docs/MIGRATION.md §"Production stage
-# additions". `gettext-base socat xvfb x11vnc sshpass openssh-client sudo
-# telnet` are already in the upstream image; listed here only as a safety
-# net in case a rebase loses them.
+# Runtime packages. `gettext-base socat xvfb x11vnc sshpass openssh-client
+# sudo telnet` are already in the upstream image; listed nowhere here
+# because the upstream provides them. We add:
+#   - python3 + python3-gi + gir1.2-atspi-2.0 + at-spi2-core: the Python
+#     controller still does `from gi.repository import Atspi` at module
+#     load. The AT-SPI bridge is disabled in the JVM (see
+#     gateway_controller.py launch_gateway) and the bus daemons are no
+#     longer started, but the typelib + libatspi.so.0 must be installable
+#     for the import to succeed.
+#   - matchbox-window-manager: Xvfb has no concept of focused window
+#     without a WM, and Gateway's input routing depends on focus.
+#   - curl: used by scripts/healthcheck.sh.
 RUN apt-get update -y \
  && apt-get install --no-install-recommends --yes \
       python3 python3-gi gir1.2-atspi-2.0 at-spi2-core \
-      libatk-wrapper-java libatk-wrapper-java-jni dbus-x11 \
       matchbox-window-manager curl \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
-# Configure the Java accessibility bridge into Gateway's JRE. Handles both
-# amd64 (install4j JRE at /usr/local/i4j_jres/...) and arm64 (Zulu JRE at
-# /usr/local/zulu17.*). See docs/ARCHITECTURE.md for why the .so must live
-# in the JRE lib dir.
-RUN GW_JAVA=$(find /usr/local/i4j_jres -name java -type f 2>/dev/null | head -1); \
-    if [ -z "$GW_JAVA" ]; then \
-      GW_JAVA=$(find /usr/local -path "*/zulu*/bin/java" -type f 2>/dev/null | head -1); \
-    fi; \
-    if [ -z "$GW_JAVA" ]; then \
-      echo "ERROR: no Gateway JRE found under /usr/local"; exit 1; \
-    fi; \
-    JAVA_HOME=$(dirname $(dirname "$GW_JAVA")); \
-    echo "Configuring ATK bridge for JRE at $JAVA_HOME"; \
-    echo "assistive_technologies=org.GNOME.Accessibility.AtkWrapper" \
-      > "$JAVA_HOME/conf/accessibility.properties"; \
-    JNI_SO=$(find /usr -name "libatk-wrapper.so*" -type f 2>/dev/null | head -1); \
-    if [ -z "$JNI_SO" ]; then echo "ERROR: libatk-wrapper.so not found"; exit 1; fi; \
-    cp "$JNI_SO" "$JAVA_HOME/lib/"
 
 # Install the controller artifacts from the local build. Run `make` before
 # `docker build` so dist/ is populated.
 COPY dist/gateway-input-agent.jar /home/ibgateway/gateway-input-agent.jar
 COPY dist/gateway_controller.py  /home/ibgateway/scripts/gateway_controller.py
 
-# Swap in the USE_PYATSPI2_CONTROLLER-aware run.sh. Replaces upstream's
-# IBC-first dispatch with a path that starts the controller, waits for
-# its readiness signal, then brings up socat port forwarding.
+# Swap in the controller-aware run.sh. Replaces upstream's IBC-first
+# dispatch with a path that starts the controller, waits for its
+# readiness signal, then brings up socat port forwarding.
 COPY docker/run.sh /home/ibgateway/scripts/run.sh
 
 # Healthcheck shim — curls the controller's /health endpoint on the

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Build and package the IB Gateway pyatspi2 controller.
+# Build and package the IB Gateway controller.
 #
 # Targets:
 #   make              — build the agent jar + stage the controller in dist/
@@ -13,7 +13,7 @@
 # Version is overridable on the command line:
 #   make release VERSION=0.2.0
 
-VERSION          ?= 0.5.9
+VERSION          ?= 0.5.13
 NAME             := ibg-controller
 DIST             := dist
 AGENT_SRC        := agent/GatewayInputAgent.java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d --name ibkr \
 ```
 
 Tags published: `:latest`, `:<major>.<minor>` (e.g. `:0.5`), and
-`:v<major>.<minor>.<patch>` (e.g. `:v0.5.9`). Every tag is signed with
+`:v<major>.<minor>.<patch>` (e.g. `:v0.5.13`). Every tag is signed with
 cosign via Sigstore keyless signing — see [`SECURITY.md`](SECURITY.md)
 for the verification recipe. For reproducible deployments, pin to a
 digest (`ghcr.io/code-hustler-ft3d/ibg-controller@sha256:...`) — the
@@ -56,7 +56,7 @@ digest is printed in each release's CI log.
 >     environment:
 >       TRADING_MODE: paper
 >       TWS_SERVER_PAPER: cdc1.ibllc.com
->       USE_PYATSPI2_CONTROLLER: "yes"
+>       USE_IBG_CONTROLLER: "yes"
 >       # ... your other env vars
 > ```
 
@@ -71,11 +71,8 @@ RUN cd /root/ibg-controller && \
     cd / && rm -rf /root/ibg-controller /root/build
 
 # In the production stage, add these packages:
-#   python3 python3-gi gir1.2-atspi-2.0 at-spi2-core
-#   libatk-wrapper-java libatk-wrapper-java-jni
-#   dbus-x11 matchbox-window-manager
-# and follow docs/MIGRATION.md for the JRE accessibility bridge
-# configuration.
+#   python3 matchbox-window-manager
+# and follow docs/MIGRATION.md for the rest.
 ```
 
 Then at `docker run` time:
@@ -84,7 +81,7 @@ Then at `docker run` time:
 docker run -d --name ibkr \
   --env-file /path/to/your/.env \
   -e TRADING_MODE=paper \
-  -e USE_PYATSPI2_CONTROLLER=yes \
+  -e USE_IBG_CONTROLLER=yes \
   -e TWS_SERVER_PAPER=cdc1.ibllc.com \
   -e TWOFACTOR_CODE=<your TOTP secret> \
   -p 127.0.0.1:4002:4004 \
@@ -101,9 +98,9 @@ Why each piece is necessary: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
 A ready-to-use `Dockerfile` is shipped at the repo root. It extends
 [`gnzsnz/ib-gateway-docker`](https://github.com/gnzsnz/ib-gateway-docker),
-installs the AT-SPI stack, configures the Java accessibility bridge
-into Gateway's JRE, and drops the controller artifacts from `dist/`
-into `/home/ibgateway/`:
+adds the small set of runtime packages the controller needs (`python3`
++ `matchbox-window-manager`), and drops the controller artifacts from
+`dist/` into `/home/ibgateway/`:
 
 ```bash
 # Build the agent jar and stage the controller
@@ -129,8 +126,8 @@ Quick start above instead.
 | **IB Gateway** | Tested on **10.45.1c**. Should work on any 10.x with a compatible install4j launcher and a Zulu JRE 17+. |
 | **Python 3.10+** | For f-strings with `=` and type hints. |
 | **JDK 17+** | Only at *build* time, for the agent. Runtime uses Gateway's bundled Zulu JRE. |
-| **Ubuntu packages** | `python3 python3-gi gir1.2-atspi-2.0 at-spi2-core libatk-wrapper-java libatk-wrapper-java-jni dbus-x11 matchbox-window-manager` |
-| **JRE config** | `$JAVA_HOME/conf/accessibility.properties` with `assistive_technologies=org.GNOME.Accessibility.AtkWrapper`, and `libatk-wrapper.so` copied into `$JAVA_HOME/lib/` |
+| **Ubuntu packages** | `python3 matchbox-window-manager` (matchbox provides focus routing for Xvfb; Xvfb itself ships in the upstream `gnzsnz/ib-gateway` image) |
+| **JRE config** | None. Pre-v0.5.13 the image wrote `accessibility.properties` and copied `libatk-wrapper.so` into the JRE; both were dropped after v0.5.12 disabled the AT-SPI bridge in the JVM. |
 
 ## Compatibility table
 
@@ -171,22 +168,19 @@ corresponding product.
                    ┌────────────────────────────────────────┐
                    │  Docker container (headless)           │
                    │                                        │
-                   │  Xvfb :1  ← matchbox WM               │
+                   │  Xvfb :1  ← matchbox WM                │
                    │     │                                  │
                    │     ↓                                  │
                    │  IB Gateway JVM                        │
-                   │  ├─ -javaagent:gateway-input-agent.jar │
-                   │  │      │                              │
-                   │  │      ↓                              │
-                   │  │   Unix socket (/tmp/gateway-input-{mode}.sock)
-                   │  │      ↑                              │
-                   │  └─ AT-SPI2 (org.GNOME.Accessibility.AtkWrapper)
-                   │         │                              │
-                   │         ↓                              │
+                   │  └─ -javaagent:gateway-input-agent.jar │
+                   │            │                           │
+                   │            ↓                           │
+                   │     Unix socket (/tmp/gateway-input-{mode}.sock)
+                   │            ↑                           │
                    │  gateway_controller.py (Python)        │
-                   │    ├─ pyatspi2: find components, click │
-                   │    ├─ agent socket: type text, set     │
-                   │    │    config, navigate JTree         │
+                   │    ├─ agent socket: discover windows,  │
+                   │    │    type text, click, navigate     │
+                   │    │    JTree                          │
                    │    ├─ state machine: login → 2FA →     │
                    │    │    config → ready → monitor       │
                    │    ├─ IBC-compat command server (TCP)  │
@@ -195,27 +189,25 @@ corresponding product.
                    └────────────────────────────────────────┘
 ```
 
-- **Python controller** does component discovery, clicks, state observation,
-  the re-auth monitor loop, and the IBC-compat command server.
+- **Python controller** runs the state machine, the re-auth monitor
+  loop, and the IBC-compat command server. All UI work is delegated
+  to the in-JVM agent over the Unix socket.
 - **Java agent** (~750 lines) loaded via `-javaagent:` into Gateway's JVM
   exists because Gateway's Swing fields reject every external input
-  mechanism (AT-SPI `EditableText` writes return `false`, synthetic X11
-  events get filtered by Swing's AWT subsystem). The agent uses Swing's
-  own `JTextField.setText()`, `AbstractButton.doClick()`,
+  mechanism (synthetic X11 events get filtered by Swing's AWT
+  subsystem; AT-SPI `EditableText` writes return `false`). The agent
+  uses Swing's own `JTextField.setText()`, `AbstractButton.doClick()`,
   `JTree.setSelectionPath()`, and `JToggleButton.doClick()` — the only
-  things that actually work.
-- **AT-SPI2** historically drove component discovery and button clicks
-  in the main window. **As of v0.5.12 the JVM no longer connects to
-  AT-SPI** — the `AtkWrapper` bridge is disabled via
-  `-Djavax.accessibility.assistive_technologies=` to prevent an
-  intra-JVM Swing-dispatch deadlock that surfaced as a misleading
-  `CCP LOCKOUT DETECTED` warning. All login-UI interaction now
-  routes through the agent socket. The diagram above shows the
-  pre-v0.5.12 architecture; post-v0.5.12 the AT-SPI2 line in the
-  Gateway JVM is dormant. See [CHANGELOG.md](CHANGELOG.md) v0.5.12
-  for the deadlock thread-dump evidence and
-  [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) sections 3 and 4
-  for what the JRE-side configuration *would* do if re-enabled.
+  things that actually work — plus `Window.getWindows()` for component
+  discovery.
+- **No AT-SPI / ATK in the runtime path.** Earlier versions used the
+  AT-SPI2 `AtkWrapper` bridge for component discovery and button
+  clicks. v0.5.12 disabled the bridge in the JVM after a thread-dump
+  showed `AtkWrapper$5.propertyChange` deadlocking on
+  `JProgressBar.setValue` calls during login (surfaced as a misleading
+  `CCP LOCKOUT DETECTED` warning); v0.5.13 removed the install-time
+  ATK packages and JRE configuration entirely. See
+  [CHANGELOG.md](CHANGELOG.md) v0.5.12 / v0.5.13 for the full record.
 
 Full diagnostic history and architectural reasoning: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
@@ -349,7 +341,7 @@ JVM restart exhaustion, Gateway JVM crash): [`docs/DISCONNECT_RECOVERY.md`](docs
 ### Product selector (v0.2)
 | Var | Notes |
 |---|---|
-| `GATEWAY_OR_TWS` | `gateway` (default) or `tws`. Switches launcher discovery (`$TWS_PATH/ibgateway/...` vs `$TWS_PATH/tws/...`) and AT-SPI app name search between IB Gateway and Trader Workstation. Code path unit-tested; live validation pending a TWS-with-controller Dockerfile variant. |
+| `GATEWAY_OR_TWS` | `gateway` (default) or `tws`. Switches launcher discovery (`$TWS_PATH/ibgateway/...` vs `$TWS_PATH/tws/...`) and the agent's window-title match between IB Gateway and Trader Workstation. Code path unit-tested; live validation pending a TWS-with-controller Dockerfile variant. |
 
 ### Dual-mode per-instance (v0.2.1)
 | Var | Notes |
@@ -399,8 +391,8 @@ make
 # Syntax-check the Python controller + validate the agent jar manifest
 make test
 
-# Create a release tarball (dist/ibg-controller-0.5.9.tar.gz)
-make release VERSION=0.5.9
+# Create a release tarball (dist/ibg-controller-0.5.13.tar.gz)
+make release VERSION=0.5.13
 
 # Install directly into a running ibgateway home (for dev on host, or
 # as called by the Docker image's setup stage)
@@ -412,7 +404,7 @@ Build requires a JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.
 ### Installing from a release tarball (for consumers who don't build)
 
 ```bash
-VER=0.5.9
+VER=0.5.13
 curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${VER}/ibg-controller-${VER}.tar.gz
 tar -xzf ibg-controller-${VER}.tar.gz
 cd ibg-controller-${VER}
@@ -421,8 +413,8 @@ DESTDIR=/home/ibgateway ./install.sh
 
 The tarball layout is flat:
 ```
-ibg-controller-0.5.9/
-├── gateway-input-agent.jar    ← installed to $DESTDIR/gateway-input-agent.jar
+ibg-controller-0.5.13/
+├── gateway-input-agent.jar   ← installed to $DESTDIR/gateway-input-agent.jar
 ├── gateway_controller.py      ← installed to $DESTDIR/scripts/gateway_controller.py
 ├── ibc_config_to_env.py       ← one-shot IBC config.ini → env migration tool
 ├── install.sh
@@ -532,13 +524,11 @@ stuck-connecting case won't show in `launcher.log`; check the
 controller's own logs for the "stuck in 'connecting to server'"
 warning instead.
 
-### "Gateway PID unknown (agent never reported one) — cannot proceed without a JVM identity" (v0.5.12+)
+### "Gateway PID unknown (agent never reported one) — cannot proceed without a JVM identity"
 
-In v0.5.12+ Gateway no longer registers with the AT-SPI desktop
-tree (the bridge is intentionally disabled — see CHANGELOG.md). App
-discovery now relies on the input agent reporting its JVM PID
-through the Unix socket instead. If you see this error, the agent
-itself failed to start. Check:
+App discovery relies on the input agent reporting its JVM PID through
+the Unix socket. If you see this error, the agent itself failed to
+start. Check:
 
 1. The `-javaagent:/home/ibgateway/gateway-input-agent.jar=...`
    flag is in the JVM's command line. Inside the container:
@@ -549,19 +539,11 @@ itself failed to start. Check:
 3. `/tmp/jvm_console_${TRADING_MODE}.log` — added in v0.5.12. Check
    the JVM console for agent boot errors.
 
-### Pre-v0.5.12: "IBKR Gateway never appeared in AT-SPI desktop tree within 120s"
-
-This message no longer applies in v0.5.12+ (Gateway intentionally
-does not register with AT-SPI). For pre-v0.5.12 deployments, the
-ATK bridge didn't load. Check:
-
-1. `ls $JAVA_HOME/conf/accessibility.properties` inside the container —
-   must contain `assistive_technologies=org.GNOME.Accessibility.AtkWrapper`
-2. `ls $JAVA_HOME/lib/libatk-wrapper.so` — must exist (copied from
-   `/usr/lib/*/jni/libatk-wrapper.so` at image build time)
-3. `at-spi-bus-launcher --launch-immediately` was started BEFORE
-   Gateway. If the accessibility bus isn't up when Gateway's JVM
-   initializes, the ATK wrapper silently skips itself.
+> **Pre-v0.5.12 deployments only:** if you're still on a release that
+> used the AT-SPI desktop tree for app discovery and you see "IBKR
+> Gateway never appeared in AT-SPI desktop tree within 120s",
+> upgrade. v0.5.12+ doesn't use AT-SPI at all and v0.5.13 removed the
+> ATK install steps from the image; both error modes are gone.
 
 ### "Existing session detected" dialog keeps appearing in a loop
 

--- a/agent/GatewayInputAgent.java
+++ b/agent/GatewayInputAgent.java
@@ -35,7 +35,7 @@ import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 
 /**
- * In-JVM helper for the pyatspi2 gateway controller.
+ * In-JVM helper for the ibg-controller Python process.
  *
  * Provides the operations that can't be done from outside the JVM.
  * Loaded via -javaagent:gateway-input-agent.jar in
@@ -63,9 +63,8 @@ import javax.swing.tree.TreePath;
  *   CLOSE_WIN <title_substr>              → OK | ERR not_found window_title_substring=...
  *
  * Component lookup is by AccessibleContext.getAccessibleName() or by
- * setText()/AbstractButton.getText(), matching what AT-SPI exposes.
- * The Python controller's selectors map 1:1 to what this agent looks
- * up.
+ * setText()/AbstractButton.getText(). The Python controller's selectors
+ * map 1:1 to what this agent looks up.
  *
  * Threading rules borrowed from Lcstyle's ibctl agent:
  *   - SETTEXT/GETTEXT/JTREE_SELECT_PATH/SETTEXT_BY_LABEL use
@@ -259,13 +258,12 @@ public class GatewayInputAgent {
             }
             case "WAIT_LOGIN_FRAME": {
                 // v0.4.3: block until the Gateway login frame is showing
-                // AND no modal dialog is overlaying it. Replaces
-                // attempt_inplace_relogin's pyatspi
-                // `wait_for(app, "password text")` wait, which times out
-                // while Gateway's "Attempt N: connecting to server" modal
-                // is up because AT-SPI filters the role. Swing's
-                // isShowing() is truthful regardless of modal overlay, so
-                // the JVM-side lookup sees the frame correctly.
+                // AND no modal dialog is overlaying it. Replaces an
+                // earlier pyatspi-based wait that timed out while
+                // Gateway's "Attempt N: connecting to server" modal was
+                // up (AT-SPI filtered the role). Swing's isShowing() is
+                // truthful regardless of modal overlay, so the JVM-side
+                // lookup sees the frame correctly.
                 return doWaitLoginFrame(rest);
             }
             case "CLOSE_WIN": {

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -11,20 +11,31 @@ echo "*************************************************************************"
 # shellcheck disable=SC1091
 source "${SCRIPT_PATH}/common.sh"
 
+# Backward compatibility: USE_PYATSPI2_CONTROLLER is the historical name
+# for the controller toggle (the controller used to walk the AT-SPI
+# desktop tree via pyatspi). v0.5.12+ no longer registers Gateway with
+# AT-SPI at all; the env var is now just the IBC-vs-controller switch.
+# USE_IBG_CONTROLLER is the preferred name. Honor the old name for
+# existing compose files but warn so users migrate.
+if [ -z "${USE_IBG_CONTROLLER:-}" ] && [ -n "${USE_PYATSPI2_CONTROLLER:-}" ]; then
+	USE_IBG_CONTROLLER="$USE_PYATSPI2_CONTROLLER"
+	echo ".> WARNING: USE_PYATSPI2_CONTROLLER is deprecated; rename to USE_IBG_CONTROLLER"
+fi
+export USE_IBG_CONTROLLER
+
 # shellcheck disable=SC2329
 stop_ibc() {
 	echo ".> 😘 Received SIGINT or SIGTERM. Shutting down IB Gateway."
 
 	# 2026-04-27 fix: SIGTERM the controllers FIRST so they can drive
-	# clean logout via the AT-SPI input agent BEFORE we tear down the
-	# X server / AT-SPI / socat infrastructure they depend on. The old
-	# order (Xvfb killed first, controllers signalled last) made the
-	# v0.5.6 clean-logout pipeline impossible: AWT's WINDOW_CLOSING
-	# dispatch needs a live X11 connection to fire Gateway's
-	# WindowListener, so by the time the controller's shutdown handler
-	# tried clean logout, AWT EventQueue was blocked on a dead X11
-	# socket and the JVM hung until SIGKILL — stranding the IBKR slot
-	# every container restart.
+	# clean logout via the input agent BEFORE we tear down the X server
+	# / socat infrastructure they depend on. The old order (Xvfb killed
+	# first, controllers signalled last) made the v0.5.6 clean-logout
+	# pipeline impossible: AWT's WINDOW_CLOSING dispatch needs a live
+	# X11 connection to fire Gateway's WindowListener, so by the time
+	# the controller's shutdown handler tried clean logout, AWT
+	# EventQueue was blocked on a dead X11 socket and the JVM hung
+	# until SIGKILL — stranding the IBKR slot every container restart.
 	echo ".> Stopping IBC / controller (clean logout phase)."
 	kill -SIGTERM "${pid[@]}" 2>/dev/null || true
 	# Wait up to 60s for controllers to do clean logout + JVM exit.
@@ -67,10 +78,8 @@ stop_ibc() {
 		pkill socat
 	fi
 	#
-	if [ "$USE_PYATSPI2_CONTROLLER" = "yes" ]; then
-		echo ".> Stopping AT-SPI infrastructure."
-		pkill -f at-spi2-registryd 2>/dev/null
-		pkill -f at-spi-bus-launcher 2>/dev/null
+	if [ "$USE_IBG_CONTROLLER" = "yes" ]; then
+		echo ".> Stopping window manager."
 		pkill -f matchbox-window-manager 2>/dev/null
 		# Clean up readiness file
 		rm -f /tmp/gateway_ready
@@ -124,55 +133,9 @@ start_IBC() {
 	echo "$_p" >"/tmp/pid_${TRADING_MODE}"
 }
 
-# ── pyatspi2 controller path ────────────────────────────────────────────
-# Opt-in via USE_PYATSPI2_CONTROLLER=yes. Default falls back to IBC.
-
-start_dbus_session() {
-	# Start a per-container D-Bus session bus. AT-SPI's accessibility bus
-	# uses this to publish the org.a11y.Bus name.
-	if [ -n "$DBUS_SESSION_BUS_ADDRESS" ]; then
-		echo ".> D-Bus session bus already set: $DBUS_SESSION_BUS_ADDRESS"
-		return 0
-	fi
-	echo ".> Starting D-Bus session bus."
-	eval "$(dbus-launch --sh-syntax)"
-	export DBUS_SESSION_BUS_ADDRESS DBUS_SESSION_BUS_PID
-	echo ".>		D-Bus: $DBUS_SESSION_BUS_ADDRESS"
-}
-
-start_atspi() {
-	# Start at-spi-bus-launcher (claims org.a11y.Bus on the session bus,
-	# spawns a separate dbus-daemon for the accessibility bus, and
-	# auto-starts at-spi2-registryd on it). Critical for the JVM to find
-	# the accessibility registry via org.a11y.Bus.GetAddress.
-	echo ".> Starting AT-SPI infrastructure."
-	local launcher=""
-	for p in /usr/libexec/at-spi-bus-launcher /usr/lib/at-spi2-core/at-spi-bus-launcher; do
-		if [ -x "$p" ]; then
-			launcher="$p"
-			break
-		fi
-	done
-	if [ -z "$launcher" ]; then
-		echo ".> ERROR: at-spi-bus-launcher not found"
-		return 1
-	fi
-	"$launcher" --launch-immediately &
-	sleep 2
-	# at-spi-bus-launcher should auto-start the registryd via D-Bus
-	# activation, but start it explicitly too in case activation is slow.
-	local registryd=""
-	for p in /usr/libexec/at-spi2-registryd /usr/lib/at-spi2-core/at-spi2-registryd; do
-		if [ -x "$p" ]; then
-			registryd="$p"
-			break
-		fi
-	done
-	if [ -n "$registryd" ]; then
-		"$registryd" &
-		sleep 1
-	fi
-}
+# ── ibg-controller path ─────────────────────────────────────────────────
+# Opt-in via USE_IBG_CONTROLLER=yes (historically USE_PYATSPI2_CONTROLLER;
+# alias handled at the top of this script). Default falls back to IBC.
 
 start_window_manager() {
 	# Xvfb has no window manager by default, which leaves no focused
@@ -297,7 +260,7 @@ start_process() {
 	# apply settings
 	apply_settings
 
-	if [ "$USE_PYATSPI2_CONTROLLER" = "yes" ]; then
+	if [ "$USE_IBG_CONTROLLER" = "yes" ]; then
 		# Controller path: launch the controller first, wait for it to
 		# signal readiness, THEN start port forwarding. This fixes the
 		# long-standing issue where socat starts before Gateway is logged
@@ -325,15 +288,13 @@ fi
 # start Xvfb
 start_xvfb
 
-# AT-SPI infrastructure (only when using the pyatspi2 controller).
-# Must come AFTER start_xvfb (Xvfb provides DISPLAY) but BEFORE the
-# controller launches Gateway, because the JVM needs to find the
-# accessibility bus during static initialization.
-if [ "$USE_PYATSPI2_CONTROLLER" = "yes" ]; then
+# Window manager (only when using the ibg-controller path). Xvfb has no
+# concept of focused window without a WM and Gateway's input routing
+# depends on focus. Must come AFTER start_xvfb so DISPLAY is set, and
+# BEFORE the controller launches Gateway.
+if [ "$USE_IBG_CONTROLLER" = "yes" ]; then
 	wait_x_socket
 	start_window_manager
-	start_dbus_session
-	start_atspi
 fi
 
 # setup SSH Tunnel
@@ -419,11 +380,11 @@ if [ -n "$IBC_SCRIPTS" ]; then
 fi
 
 # Controller-path analog: CONTROLLER_SCRIPTS runs user scripts after
-# the pyatspi2 controller has signalled readiness (and in dual mode
-# after BOTH instances have signalled). Users who previously used
-# IBC_SCRIPTS for post-login hooks can use this with the same
-# directory-of-shell-scripts semantics.
-if [ "$USE_PYATSPI2_CONTROLLER" = "yes" ] && [ -n "${CONTROLLER_SCRIPTS:-}" ]; then
+# the controller has signalled readiness (and in dual mode after BOTH
+# instances have signalled). Users who previously used IBC_SCRIPTS for
+# post-login hooks can use this with the same directory-of-shell-scripts
+# semantics.
+if [ "$USE_IBG_CONTROLLER" = "yes" ] && [ -n "${CONTROLLER_SCRIPTS:-}" ]; then
 	run_scripts "$HOME/$CONTROLLER_SCRIPTS"
 fi
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,11 +7,12 @@ look here.
 
 ## The core insight
 
-**The IBC replacement has to be in-process with Gateway's JVM for text
-input, and out-of-process for everything else.**
+**The IBC replacement has to be in-process with Gateway's JVM. The
+Python controller is the brain; an in-JVM Java agent is the only path
+that can actually drive Swing.**
 
 IB Gateway's Swing-based login form rejects every external input
-mechanism we tried:
+mechanism we tried during the initial spike:
 
 | Mechanism | Result |
 |---|---|
@@ -28,19 +29,22 @@ Inside the JVM, **`JTextField.setText()` works instantly**. IBC works
 because it runs as the JVM's main class; Lcstyle's `ibctl` works because
 it uses `-javaagent:` to inject a Java agent. We use the same trick.
 
-**But** everything else — component discovery, button clicks, state
-observation, dialog detection, monitoring for re-auth — works perfectly
-from outside the JVM via AT-SPI2, using the public Swing accessibility
-API.
+We originally drove component discovery and button clicks from the
+Python side via AT-SPI2. v0.5.12 retired that path after the
+java-atk-wrapper bridge was found to deadlock on `JProgressBar.setValue`
+calls during login (intra-JVM, manifest as `CCP LOCKOUT DETECTED`
+warnings — see CHANGELOG.md v0.5.12 for the SIGQUIT thread-dump
+evidence). v0.5.13 removed the AT-SPI install steps and JRE
+configuration from the image entirely.
 
 So the architecture splits:
 - **Python controller, out-of-process**: state machine, monitoring,
-  discovery, button clicks via `Atspi.Action.do_action`. All the logic
-  and the bulk of the code.
-- **Tiny Java agent, in-process**: loaded via `-javaagent:`, exposes
-  a Unix-socket protocol with two operations: "type text into component
-  named X" and "click button named X". ~750 lines of Java, rarely
-  touched.
+  re-auth loop, IBC-compat command server. All the logic and the bulk
+  of the code.
+- **Java agent, in-process**: loaded via `-javaagent:`, exposes a
+  Unix-socket protocol for window discovery, text input, button
+  clicks, JTree navigation, and clean-logout dispatch. ~750 lines of
+  Java.
 
 ## The pieces and why each one is necessary
 
@@ -56,93 +60,30 @@ When we tried to inject events without a WM, they went nowhere. With
 `matchbox-window-manager` (chosen for being tiny and not adding titlebars:
 `matchbox-window-manager -use_titlebar no`), focus routing works.
 
-### 2. D-Bus session bus
+### 2. AT-SPI / ATK / D-Bus — all gone as of v0.5.13
 
-AT-SPI2 uses a D-Bus session bus to publish the `org.a11y.Bus` service
-name. Without a session bus, there's no place for the bus to publish
-itself. `dbus-launch --sh-syntax` produces a fresh session bus for the
-container.
+> **Historical context.** Pre-v0.5.12 the controller drove component
+> discovery and button clicks via Python's `pyatspi2` against
+> Gateway's `org.GNOME.Accessibility.AtkWrapper` Java bridge. That
+> required a D-Bus session bus, the `at-spi-bus-launcher` /
+> `at-spi2-registryd` daemons, the `libatk-wrapper-java*` packages,
+> and a build-time write of `accessibility.properties` + a copy of
+> `libatk-wrapper.so` into `$JAVA_HOME/lib/`.
+>
+> v0.5.12 disabled the bridge in the JVM after a SIGQUIT thread dump
+> showed `AtkWrapper$5.propertyChange` deadlocking on
+> `JProgressBar.setValue` during login (`CCP LOCKOUT DETECTED` was a
+> misnomer — IBKR was never reached). v0.5.13 removed the install
+> steps, the bus daemons, and the JRE accessibility configuration
+> from the image. All component discovery, text input, and clicks
+> now route through the in-JVM agent (see section 4 below). The JVM
+> is still launched with
+> `-Djavax.accessibility.assistive_technologies=` as
+> defense-in-depth in case a base image ships the JAR pre-installed.
+>
+> The full thread-dump and rationale lives in CHANGELOG.md v0.5.12.
 
-### 3. AT-SPI2 infrastructure (`at-spi-bus-launcher` + `at-spi2-registryd`)
-
-> **v0.5.12: the JVM no longer connects to AT-SPI.** The
-> `org.GNOME.Accessibility.AtkWrapper` bridge ships an AWT
-> property-change listener whose `emitSignal` JNI re-entry deadlocks
-> on a single Swing dispatch (see CHANGELOG.md v0.5.12). v0.5.12
-> disables the bridge by passing
-> `-Djavax.accessibility.assistive_technologies=` (empty value) to
-> the JVM. The AT-SPI infrastructure described below is **still
-> launched** because matchbox-WM and Xvfb expect it to be present,
-> but the JVM does not register with the desktop tree, and the
-> Python controller's discovery + login-UI code paths route
-> exclusively through the in-JVM `gateway-input-agent` socket
-> (see section 6 below). The `Atspi.get_desktop(0)` path described
-> here remains accurate for *how the bus would be reached*, but
-> Gateway's application no longer appears there.
-
-AT-SPI2 actually uses **two** buses: the normal D-Bus session bus, and
-a **separate accessibility bus** managed by `at-spi-bus-launcher`.
-Applications (like Gateway's JVM) find the accessibility bus via the
-`org.a11y.Bus.GetAddress` method call on the session bus, which
-`at-spi-bus-launcher` services.
-
-**Don't start `at-spi2-registryd` directly on the session bus** — we
-tried that early in the spike and it silently failed. You need to start
-`at-spi-bus-launcher --launch-immediately`, which will:
-1. Claim `org.a11y.Bus` on the session bus
-2. Spawn a fresh `dbus-daemon` for the accessibility bus
-3. Start `at-spi2-registryd` on the accessibility bus (via D-Bus activation)
-
-After this, Python's `Atspi.get_desktop(0)` returns something useful
-and Gateway's application appears in the tree.
-
-### 4. Java accessibility configuration in the JRE
-
-> **v0.5.12: this configuration is intentionally inert at runtime.**
-> The Dockerfile still writes `accessibility.properties` and copies
-> `libatk-wrapper.so` into `$JAVA_HOME/lib/` (we keep it for
-> reproducibility against the upstream `gnzsnz/ib-gateway` image),
-> but the controller passes `-Djavax.accessibility.assistive_technologies=`
-> to the JVM, which overrides the file-based setting and skips
-> `AtkWrapper` instantiation. The configuration below is what the
-> JRE *would* load if the override were removed — kept here as
-> reference for anyone restoring the bridge.
-
-Gateway's bundled JRE needs to load `org.GNOME.Accessibility.AtkWrapper`
-as an assistive technology at startup. This requires two things:
-
-**a)** A file at `$JAVA_HOME/conf/accessibility.properties` containing:
-```
-assistive_technologies=org.GNOME.Accessibility.AtkWrapper
-```
-
-**b)** The native `libatk-wrapper.so` placed at `$JAVA_HOME/lib/libatk-wrapper.so`
-(not just on `LD_LIBRARY_PATH`). This is because the Java wrapper jar
-is loaded via `-Xbootclasspath/a:/usr/share/java/java-atk-wrapper.jar`,
-and `System.loadLibrary("atk-wrapper")` from a boot-classpath class
-searches `sun.boot.library.path` (which is `$JAVA_HOME/lib`) — NOT
-`java.library.path`.
-
-The `libatk-wrapper-java-jni` Ubuntu package ships the .so at
-`/usr/lib/<arch>-linux-gnu/jni/libatk-wrapper.so`. We copy it to
-`$JAVA_HOME/lib/` at build time.
-
-#### JRE path discovery
-
-IB Gateway's JRE lives in different places depending on architecture:
-- **amd64**: install4j-bundled at `/usr/local/i4j_jres/<install-id>/<version>-zulu/`
-  (the install ID is random per-install)
-- **arm64**: system Zulu at `/usr/local/zulu17.<full-version>/`
-  (downloaded as a tarball during the Docker build — no install4j)
-
-The Dockerfile build-time step does:
-```bash
-GW_JAVA=$(find /usr/local/i4j_jres -name java -type f 2>/dev/null | head -1)
-[ -z "$GW_JAVA" ] && GW_JAVA=$(find /usr/local -path "*/zulu*/bin/java" -type f 2>/dev/null | head -1)
-JAVA_HOME=$(dirname $(dirname "$GW_JAVA"))
-```
-
-### 5. Gateway launch via install4j launcher
+### 3. Gateway launch via install4j launcher
 
 The controller launches Gateway via its bundled launcher script at
 `$TWS_PATH/ibgateway/<version>/ibgateway`. That script is generated by
@@ -169,7 +110,7 @@ persistent auth-timeout bug found during initial deployment.
 --add-opens=java.base/java.util=ALL-UNNAMED
 --add-opens=java.desktop/javax.swing=ALL-UNNAMED
 ... (19 module-access flags total)
--Xbootclasspath/a:/usr/share/java/java-atk-wrapper.jar
+-Djavax.accessibility.assistive_technologies=
 -DjtsConfigDir=/home/ibgateway/Jts
 -javaagent:/home/ibgateway/gateway-input-agent.jar=/tmp/gateway-input.sock
 ```
@@ -179,9 +120,11 @@ persistent auth-timeout bug found during initial deployment.
   system blocks this by default. These are the same 19 flags IBC's
   `ibcstart.sh` passes; the install4j launcher's `.vmoptions` file
   does not include them.
-- **`-Xbootclasspath/a:`** puts the AT-SPI Java wrapper jar on the boot
-  classpath so the JVM can find `org.GNOME.Accessibility.AtkWrapper`
-  referenced in `accessibility.properties`.
+- **`-Djavax.accessibility.assistive_technologies=`** (empty value)
+  prevents the JRE from instantiating any AT-SPI assistive technology
+  even on a base image that has `libatk-wrapper-java` pre-installed
+  (the controller's own image dropped that package in v0.5.13). See
+  the historical-context block above for why.
 - **`-DjtsConfigDir=`** is also set here as a belt-and-suspenders
   backup to the `-V` flag (in case the install4j launcher doesn't
   support `-V` on some platform).
@@ -189,7 +132,7 @@ persistent auth-timeout bug found during initial deployment.
   after `=` is passed to the agent as its `agentArgs` — we use it to
   pass the Unix socket path.
 
-### 6. The input agent (`gateway-input-agent.jar`)
+### 4. The input agent (`gateway-input-agent.jar`)
 
 ~750 lines of Java. Three core responsibilities (extended with additional commands in v0.2):
 
@@ -197,8 +140,8 @@ persistent auth-timeout bug found during initial deployment.
    client at a time, line-protocol, no concurrency.
 2. **Walk `Window.getWindows()`** recursively via `Container.getComponents()`
    to find Swing components. Search by `AccessibleContext.getAccessibleName()`
-   (matches what Python sees via AT-SPI) OR by window title (for
-   components that have no accessible name — see the 2FA dialog section).
+   OR by window title (for components that have no accessible name — see
+   the 2FA dialog section).
 3. **Dispatch operations on the EDT**: `SwingUtilities.invokeAndWait`
    for `SETTEXT`/`GETTEXT` (synchronous), `SwingUtilities.invokeLater`
    + `Thread.sleep(50)` for `CLICK`. We use `invokeLater` for clicks
@@ -234,16 +177,15 @@ Why each was added:
 
 - **`GET_PID`** — returns `ProcessHandle.current().pid()`. Used by the
   Python controller to disambiguate its own Gateway JVM from any other
-  Gateway JVM in the same container. Dual mode (`TRADING_MODE=both`)
-  runs two Gateway JVMs that both register as "IBKR Gateway" in AT-SPI;
-  `find_app(match_pid=...)` filters to the right one.
+  Gateway JVM in the same container. Critical for dual mode
+  (`TRADING_MODE=both`), where two Gateway JVMs run in parallel.
 - **`JTREE_SELECT_PATH`** — navigates a `JTree` to a slash-separated
   path by matching `node.toString()` at each level, expanding parents
   as it walks. Gateway's ConfigurationTree renders cells on demand via
   a `CellRendererPane` — the cell components aren't real `Container`
-  children, so AT-SPI traversal + `Atspi.Action.do_action` can't reach
-  them. The only way to drive the tree is through the `JTree` model
-  API directly from inside the JVM.
+  children, so external traversal + click can't reach them. The only
+  way to drive the tree is through the `JTree` model API directly from
+  inside the JVM.
 - **`JCHECK`** — idempotent toggle of any `JToggleButton` (covers
   `JCheckBox`, `JRadioButton`, and install4j subclasses) matched by
   accessible name or button text. Reads the current selected state
@@ -257,7 +199,7 @@ Why each was added:
   calls `commitEdit()` on `JFormattedTextField` editors so spinner
   values actually propagate to the underlying model.
 
-### 7. The Python controller (`gateway_controller.py`)
+### 5. The Python controller (`gateway_controller.py`)
 
 ~2000 lines. The state machine, in rough order:
 
@@ -268,16 +210,16 @@ Why each was added:
 2. **Wait for agent**: `agent_wait_ready()` — poll the Unix socket
    until `PING` returns `OK pong`. Then call `GET_PID` and store the
    JVM PID in the `JVM_PID` global.
-3. **Wait for AT-SPI app**: `find_app(APP_NAME_CANDIDATES, timeout=120,
-   match_pid=JVM_PID)` — poll `Atspi.get_desktop(0)` until an
-   application registers with a matching name *and* process ID. The
-   app-name candidate list is `["IBKR Gateway"]` by default, or
-   `["Trader Workstation", "IB Trader Workstation", "TWS"]` when
-   `GATEWAY_OR_TWS=tws`.
-4. **Login**: `handle_login(app)` — find the `password text` role via
-   AT-SPI, detect the login form, select trading mode (via toggle
-   button click), type credentials via the agent, click Log In via
-   `Atspi.Action.do_action`.
+3. **Resolve app handle**: `find_app(APP_NAME_CANDIDATES, timeout=120,
+   match_pid=JVM_PID)` — returns a stub Accessible carrying the
+   agent-reported JVM PID. Pre-v0.5.12 this polled the AT-SPI desktop
+   tree; post-v0.5.12 the JVM doesn't register there, so the function
+   short-circuits to a stub immediately. The handle is just used as a
+   passthrough argument and for logging.
+4. **Login**: `handle_login(app)` — wait for the login frame via
+   `WAIT_LOGIN_FRAME`, select trading mode via `JCHECK`, type
+   credentials via `SETTEXT_LOGIN_USER`/`SETTEXT_LOGIN_PASSWORD`,
+   click Log In via `CLICK`. Entirely agent-driven.
 5. **Post-login dialogs**: `handle_post_login_dialogs(app)` — polls
    up to 6s for any modal to appear, dumps each via `WINDOW`,
    recognizes `Existing session detected` by body text, clicks
@@ -316,9 +258,9 @@ Why each was added:
     after three consecutive port-closed heartbeats + a visible login
     dialog.
 
-### 8. Dual mode (`TRADING_MODE=both`) dispatch (v0.2)
+### 6. Dual mode (`TRADING_MODE=both`) dispatch (v0.2)
 
-When `TRADING_MODE=both` and `USE_PYATSPI2_CONTROLLER=yes`, `run.sh`
+When `TRADING_MODE=both` and `USE_IBG_CONTROLLER=yes`, `run.sh`
 spawns `start_process` twice in sequence — once with live env, then
 with paper env. Each invocation exports distinct per-instance values:
 
@@ -333,8 +275,8 @@ with paper env. Each invocation exports distinct per-instance values:
 Each controller launches its own Gateway JVM in its own
 `JTS_CONFIG_DIR` (`Jts_live` / `Jts_paper`) so both can write to
 `jts.ini`, encrypted state, and `launcher.log` without stepping on
-each other. `find_app(match_pid=...)` uses the per-instance JVM PID
-to pick the right AT-SPI app when both JVMs are registered.
+each other. The agent's `GET_PID` reply lets the Python controller
+identify its own JVM unambiguously.
 
 The legacy `wait_for_controller_ready` behavior (return non-zero
 under `set -Eeo pipefail`) was changed to always return 0 on

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -33,7 +33,7 @@ through the first-run wizard, log in successfully, then grab the generated
 
 ```bash
 docker run --rm --platform linux/arm64 \
-    -e USE_PYATSPI2_CONTROLLER=no  \
+    -e USE_IBG_CONTROLLER=no  \
     -e TWS_USERID=... -e TWS_PASSWORD=... \
     -e TRADING_MODE=live \
     -e VNC_SERVER_PASSWORD=changeme \

--- a/docs/FROM_IBC.md
+++ b/docs/FROM_IBC.md
@@ -310,10 +310,11 @@ forwarder or the ports your trading code connects to. The swap is
 transparent to the client side.
 
 **What about the `run.sh`?** The shipped `Dockerfile` swaps in an
-ibg-controller-aware `run.sh` that sets `USE_PYATSPI2_CONTROLLER=yes`
-and dispatches to the controller instead of IBC's jar. If you're
-building a custom image, pick up `docker/run.sh` from the release
-tarball.
+ibg-controller-aware `run.sh` that, when `USE_IBG_CONTROLLER=yes`,
+dispatches to the controller instead of IBC's jar. (The historical
+`USE_PYATSPI2_CONTROLLER=yes` is still honored as a deprecated alias
+so existing compose files keep working.) If you're building a custom
+image, pick up `docker/run.sh` from the release tarball.
 
 **Where's the `.env`? Can I commit it?** Keep credentials out of git.
 Use Docker secrets (`TWS_PASSWORD_FILE=/run/secrets/tws_password`),

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -4,11 +4,11 @@ This document covers swapping IBC for `ibg-controller` inside a
 [gnzsnz/ib-gateway-docker](https://github.com/gnzsnz/ib-gateway-docker)-style
 image. If you're running vanilla IBC today, the swap requires:
 
-- Adding a few runtime packages to your Docker image
+- Adding a couple of runtime packages to your Docker image
 - Compiling and installing the controller in your Dockerfile (or
   downloading a release)
 - Setting one new env var (`TWS_SERVER`) for the bootstrap
-- Flipping one flag (`USE_PYATSPI2_CONTROLLER=yes`) at runtime
+- Flipping one flag (`USE_IBG_CONTROLLER=yes`) at runtime
 
 Existing env vars (`TWS_USERID`, `TWS_PASSWORD`, `TRADING_MODE`,
 `TWOFACTOR_CODE`, `EXISTING_SESSION_DETECTED_ACTION`, etc.) work
@@ -49,70 +49,46 @@ RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-get install --no-install-recommends --yes \
   gettext-base socat xvfb x11vnc sshpass openssh-client sudo telnet \
-  python3 python3-gi gir1.2-atspi-2.0 at-spi2-core \
-  libatk-wrapper-java libatk-wrapper-java-jni dbus-x11 \
-  matchbox-window-manager && \
+  python3 matchbox-window-manager && \
   ...
 ```
 
 The new runtime packages:
-- `python3` + `python3-gi` + `gir1.2-atspi-2.0` — Python AT-SPI bindings
-- `at-spi2-core` — provides `at-spi-bus-launcher` and `at-spi2-registryd`
-- `libatk-wrapper-java` + `libatk-wrapper-java-jni` — bridges Swing to AT-SPI
-- `dbus-x11` — the `dbus-launch` utility
-- `matchbox-window-manager` — a minimal window manager (Xvfb has no WM
-  by default, and synthetic input handling needs a focus owner)
+- `python3` — runs `gateway_controller.py`
+- `matchbox-window-manager` — a minimal window manager (Xvfb has no
+  WM by default and Gateway's input routing depends on a focus owner)
 
-### JRE configuration at build time
-
-```dockerfile
-# Configure the Java accessibility bridge into Gateway's JRE.
-# Handles both amd64 (install4j-bundled JRE at /usr/local/i4j_jres/...)
-# and arm64 (system Zulu JRE at /usr/local/zulu17.*).
-RUN GW_JAVA=$(find /usr/local/i4j_jres -name java -type f 2>/dev/null | head -1); \
-  if [ -z "$GW_JAVA" ]; then \
-    GW_JAVA=$(find /usr/local -path "*/zulu*/bin/java" -type f 2>/dev/null | head -1); \
-  fi; \
-  if [ -z "$GW_JAVA" ]; then \
-    echo "ERROR: no Gateway JRE found"; exit 1; \
-  fi; \
-  JAVA_HOME=$(dirname $(dirname "$GW_JAVA")); \
-  echo "assistive_technologies=org.GNOME.Accessibility.AtkWrapper" \
-    > "$JAVA_HOME/conf/accessibility.properties"; \
-  JNI_SO=$(find /usr -name "libatk-wrapper.so*" -type f 2>/dev/null | head -1); \
-  cp "$JNI_SO" "$JAVA_HOME/lib/"
-```
-
-Writes `accessibility.properties` into the JRE's `conf/` directory and
-copies `libatk-wrapper.so` into the JRE's `lib/` directory. Both are
-required for Gateway's JVM to load the AT-SPI bridge at startup. See
-[ARCHITECTURE.md](ARCHITECTURE.md) for why the .so has to live in the
-JRE lib (and not just on `LD_LIBRARY_PATH`).
+> **No JRE accessibility-bridge setup is required.** Pre-v0.5.13 the
+> image installed `python3-gi gir1.2-atspi-2.0 at-spi2-core
+> libatk-wrapper-java libatk-wrapper-java-jni dbus-x11` and wrote
+> `$JAVA_HOME/conf/accessibility.properties` so the JVM could load
+> the AT-SPI `AtkWrapper` bridge for component discovery. v0.5.12
+> disabled the bridge after it was found to deadlock on
+> `JProgressBar.setValue` calls during login (intra-JVM, not
+> broker-side); v0.5.13 removed the install steps entirely. All UI
+> work now goes through the in-JVM agent socket. If you're rebasing
+> from a fork that has the old install block, drop it.
 
 ## What changes in `run.sh`
 
-The gnzsnz `run.sh` gains a branch: when `USE_PYATSPI2_CONTROLLER=yes`,
-start the AT-SPI infrastructure and launch the controller instead of IBC.
+The gnzsnz `run.sh` gains a branch: when `USE_IBG_CONTROLLER=yes`,
+start the window manager and launch the controller instead of IBC.
 When unset, fall through to the IBC path unchanged. Full diff:
 
 ```bash
 # New helper functions
-start_dbus_session() { ... }    # dbus-launch + export
-start_atspi() { ... }            # at-spi-bus-launcher + at-spi2-registryd
-start_window_manager() { ... }   # matchbox-window-manager
-start_controller() { ... }       # python3 gateway_controller.py
-wait_for_controller_ready() { ... } # block on /tmp/gateway_ready
+start_window_manager() { ... }       # matchbox-window-manager
+start_controller() { ... }           # python3 gateway_controller.py
+wait_for_controller_ready() { ... }  # block on /tmp/gateway_ready
 
 # In the Common Start section, after start_xvfb:
-if [ "$USE_PYATSPI2_CONTROLLER" = "yes" ]; then
+if [ "$USE_IBG_CONTROLLER" = "yes" ]; then
     wait_x_socket
     start_window_manager
-    start_dbus_session
-    start_atspi
 fi
 
 # In start_process(), replace the unconditional start_IBC with:
-if [ "$USE_PYATSPI2_CONTROLLER" = "yes" ]; then
+if [ "$USE_IBG_CONTROLLER" = "yes" ]; then
     start_controller
     wait_for_controller_ready
     port_forwarding                 # socat starts AFTER readiness
@@ -127,12 +103,20 @@ which fixes a long-standing issue in the IBC path where socat races the
 Gateway login and the first few API client connection attempts hit a
 closed port.
 
+> **Backwards compatibility.** The historical env-var name was
+> `USE_PYATSPI2_CONTROLLER` (the controller used to walk the AT-SPI
+> desktop tree via pyatspi). `run.sh` honors the old name as a
+> deprecated alias and prints a one-line warning at startup so
+> existing compose files keep working. Rename to `USE_IBG_CONTROLLER`
+> at your leisure.
+
 ## What changes at runtime
 
 ### New env vars
 
-- **`USE_PYATSPI2_CONTROLLER=yes`** — opts into the new path. Default
-  (unset) uses IBC as before.
+- **`USE_IBG_CONTROLLER=yes`** — opts into the new path. Default
+  (unset) uses IBC as before. The historical name
+  `USE_PYATSPI2_CONTROLLER=yes` is still honored as a deprecated alias.
 - **`TWS_SERVER`** / **`TWS_SERVER_PAPER`** — your IBKR regional server.
   See [BOOTSTRAP.md](BOOTSTRAP.md) for how to find it.
 
@@ -187,8 +171,8 @@ Reconnect Data menu item) and dispatches against TWS.
 ### Honored by v0.2 — product selector
 
 - **`GATEWAY_OR_TWS`** — `gateway` (default) or `tws`. Switches
-  launcher discovery and AT-SPI app-name search. TWS live validation
-  is pending a TWS-with-controller Dockerfile variant.
+  launcher discovery and the agent's window-title match. TWS live
+  validation is pending a TWS-with-controller Dockerfile variant.
 
 ### Env vars NOT honored (still not implemented)
 
@@ -222,7 +206,7 @@ services:
     stop_grace_period: 90s
     environment:
       TRADING_MODE: both
-      USE_PYATSPI2_CONTROLLER: "yes"
+      USE_IBG_CONTROLLER: "yes"
       # ... rest of your config
 ```
 
@@ -234,7 +218,7 @@ sequence (v0.5.11+):
 | Step | Budget | What happens |
 |---|---|---|
 | 1. SIGTERM controllers | up to 60s | Each controller calls `_attempt_clean_logout()`, which uses the in-JVM input agent to dispatch a `WINDOW_CLOSING` AWT event to Gateway's main window. Gateway's `WindowListener` runs a real CCP session-close handshake and the JVM exits. Per-controller timeout `_CLEAN_LOGOUT_TIMEOUT_SECONDS = 15s` per instance — in dual mode (`TRADING_MODE=both`) two instances run sequentially, so 30s of clean-logout is normal. The 60s outer budget covers JVM shutdown-hook work that runs after the WindowListener returns. |
-| 2. Tear down x11vnc / Xvfb / AT-SPI / socat | a few seconds | Only after controllers have exited (or 60s elapsed). |
+| 2. Tear down x11vnc / Xvfb / matchbox / socat | a few seconds | Only after controllers have exited (or 60s elapsed). |
 | 3. IBKR FIN-ACK margin | a few seconds | Server-side acknowledgement of the session-close TCP teardown. |
 
 **Total budget: ~90s.** Setting `stop_grace_period: 90s` matches that
@@ -269,7 +253,7 @@ end-to-end before that release — see CHANGELOG.md).
 
 1. Build your Docker image with the new Dockerfile.
 2. Keep your existing `docker-compose.yml` — add
-   `USE_PYATSPI2_CONTROLLER: yes` and `TWS_SERVER: <your-server>` to the
+   `USE_IBG_CONTROLLER: yes` and `TWS_SERVER: <your-server>` to the
    environment section.
 3. Leave all existing env vars as-is.
 4. `docker compose up -d` and watch logs.
@@ -320,7 +304,7 @@ end-to-end before that release — see CHANGELOG.md).
 
 ## Rolling back
 
-If the controller fails for you, flip `USE_PYATSPI2_CONTROLLER` back to
+If the controller fails for you, flip `USE_IBG_CONTROLLER` back to
 unset (or `no`). The image still contains IBC and all its dependencies.
 `run.sh`'s default branch uses IBC unchanged.
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,6 +76,45 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
+### v0.5.13
+
+**No breaking changes for image consumers.** Image cleanup — drops
+the AT-SPI / ATK install steps and JRE accessibility-bridge
+configuration that v0.5.12 made dead weight. Specifically:
+
+- `Dockerfile` no longer installs `gir1.2-atspi-2.0`-related-only
+  packages (`libatk-wrapper-java`, `libatk-wrapper-java-jni`,
+  `dbus-x11`) or writes `accessibility.properties` /
+  `libatk-wrapper.so` into the JRE. The bridge they served was
+  disabled in v0.5.12 and there are no consumers.
+- `docker/run.sh` no longer starts a D-Bus session bus or
+  `at-spi-bus-launcher` / `at-spi2-registryd`. The `stop_ibc`
+  shutdown sequence drops the matching teardown.
+- `-Xbootclasspath/a:/usr/share/java/java-atk-wrapper.jar` is
+  removed from the JVM args (the JAR is no longer in the image).
+  `-Djavax.accessibility.assistive_technologies=` stays in place
+  as defense-in-depth.
+- All user-facing docs (README, MIGRATION, ARCHITECTURE, CONTRIBUTING)
+  now reflect the post-v0.5.12 reality.
+
+**Env-var rename — backwards compatible.** The historical
+`USE_PYATSPI2_CONTROLLER=yes` toggle is renamed to
+`USE_IBG_CONTROLLER=yes`. The old name is honored as a deprecated
+alias and `run.sh` prints a one-line warning at startup so existing
+compose files keep working. Update at your leisure.
+
+**If you build your own image** based on the Dockerfile in this
+repo: the runtime apt-install line shrinks to
+`python3 matchbox-window-manager curl` and the JRE-config `RUN`
+block is gone. Pull the new `Dockerfile` and rebuild. If you've
+forked the Dockerfile, drop the AT-SPI packages and the
+accessibility.properties write yourself when you bring the fork
+forward.
+
+**No operator action required for the prebuilt GHCR image** beyond
+the redeploy. Image size shrinks slightly; nothing changes at
+runtime.
+
 ### v0.5.12
 
 **No breaking changes.** Image-internal fix for the most common

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -1,27 +1,29 @@
 #!/usr/bin/env python3
 """
-IB Gateway Controller — pyatspi2-based replacement for IBC.
+IB Gateway Controller — Python + in-JVM Java agent replacement for IBC.
 
 Single-file controller that:
-  1. Launches IB Gateway directly via its install4j launcher with the
-     ATK accessibility bridge enabled.
-  2. Walks Gateway's Swing component tree via AT-SPI2 to drive the
-     login dialog, 2FA dialog, and configuration dialogs.
-  3. Verifies every action by reading state back through the same tree.
+  1. Launches IB Gateway directly via its install4j launcher.
+  2. Drives the login dialog, 2FA dialog, and configuration dialogs via
+     an in-JVM Java agent (loaded with -javaagent:) that exposes Swing
+     operations over a Unix domain socket.
+  3. Verifies every action by reading state back through the same agent.
   4. Signals readiness via /tmp/gateway_ready so socat starts only AFTER
      login succeeds and the main window is up.
   5. Stays alive monitoring the JVM and watching for re-auth events.
 
-Why pyatspi2 and not xdotool: xdotool synthesizes X events but can't
-verify components actually received them. AT-SPI2 exposes the live Swing
-component tree (same approach IBC uses internally), so every action can
-be verified by reading state back. No pixel coordinates, no screen
-scraping.
+Why an in-JVM agent and not xdotool: xdotool synthesizes X events but
+Swing's AWT subsystem filters them. AT-SPI2 (the original approach) was
+abandoned in v0.5.12 after the java-atk-wrapper bridge was found to
+deadlock on JProgressBar.setValue calls during login. The agent uses
+Swing's own JTextField.setText() / AbstractButton.doClick() and reads
+state back via the same APIs — the only mechanisms that actually work
+against Gateway's hardened login form.
 
 Why a single Python file: the upstream maintainer (gnzsnz) doesn't write
 Java or Rust, and wants something he can read, debug, and patch when IB
-ships a new dialog on a Friday night. Python with stdlib + pyatspi2 hits
-that bar.
+ships a new dialog on a Friday night. Python stdlib + a small in-JVM
+agent hits that bar.
 
 Reference material: Lcstyle's ibctl (https://github.com/Lcstyle/ibctl)
 for dialog catalog and edge cases. Original work by @rlktradewright (IBC).
@@ -49,7 +51,7 @@ from zoneinfo import ZoneInfo
 import gi
 
 
-__version__ = "0.5.12"
+__version__ = "0.5.13"
 
 # Wall-clock timestamp recorded when the controller module loads. Reported
 # by the /health endpoint as `uptime_seconds` so monitoring can spot a
@@ -1197,9 +1199,14 @@ def launch_gateway():
         "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
     ]
     vm_params = module_access + [
-        # v0.5.12: disable the AT-SPI java-atk-wrapper bridge.
+        # v0.5.12: disable the AT-SPI java-atk-wrapper bridge as
+        # defense-in-depth. v0.5.13 removed the bridge JAR from the
+        # image entirely (so AtkWrapper has no class to load anyway),
+        # but we still set the property to an empty value so the JRE's
+        # own accessibility-property-file lookup never tries to
+        # instantiate it on a base image that ships the JAR pre-installed.
         #
-        # The bridge ships an AWT property-change listener
+        # Background: the bridge ships an AWT property-change listener
         # (AtkWrapper$5.propertyChange) that fires on every component
         # property update — including JProgressBar.setValue calls from
         # IBKR's "Connecting…" welcome screen during login. The listener's
@@ -1212,19 +1219,13 @@ def launch_gateway():
         # connection-state lock; JTS-CCPListenerS2 can't dispatch the
         # NS_AUTH_START response from IBKR; the controller times out
         # after 20 s and emits a misleading CCP LOCKOUT alert.
-        #
-        # Verified by SIGQUIT thread dump 2026-04-27.  Disabling the
-        # assistive_technologies system property prevents the JRE from
-        # instantiating AtkWrapper, so neither listener gets installed.
-        # The bootclasspath jar is left in place so that any code that
-        # imports the class explicitly still resolves.
+        # Verified by SIGQUIT thread dump 2026-04-27.
         #
         # All login-UI interaction (set credentials, click Log In, toggle
         # Live/Paper) goes through the in-JVM gateway-input-agent, which
         # uses pure Swing/AWT (Window.getWindows + SwingUtilities) and
         # does NOT depend on AT-SPI for any of its work.
         "-Djavax.accessibility.assistive_technologies=",
-        "-Xbootclasspath/a:/usr/share/java/java-atk-wrapper.jar",
         f"-DjtsConfigDir={JTS_CONFIG_DIR}",
     ]
     if os.path.exists(AGENT_JAR):

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Install the IB Gateway pyatspi2 controller from a release tarball
-# into a running ibgateway container's filesystem.
+# Install the IB Gateway controller from a release tarball into a
+# running ibgateway container's filesystem.
 #
 # Usage (from the docker image's setup stage):
-#   ARG IBG_CONTROLLER_VERSION=0.2.0
+#   ARG IBG_CONTROLLER_VERSION=0.5.13
 #   RUN curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${IBG_CONTROLLER_VERSION}/ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       tar -xzf ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       cd ibg-controller-${IBG_CONTROLLER_VERSION} && \


### PR DESCRIPTION
## Summary

Closes #1. v0.5.12 disabled the `java-atk-wrapper` bridge in the JVM after a thread-dump-confirmed deadlock during login (`AtkWrapper$5.propertyChange` re-entering through `JProgressBar.setValue` → `AtkUtil.invokeInSwing` parking on the AWT EventQueue while AWT itself was held in `AtkWrapper$6.dispatchEvent`). The README, `docs/MIGRATION.md`, `docs/ARCHITECTURE.md`, and `CONTRIBUTING.md` were still instructing users to install the AT-SPI stack, write `accessibility.properties` into the JRE, and set `USE_PYATSPI2_CONTROLLER=yes`. This release lines the image, `run.sh`, and the docs up with reality.

## What changed

**Image cleanup:**
- `Dockerfile` drops `libatk-wrapper-java`, `libatk-wrapper-java-jni`, `dbus-x11` and the `RUN` block that writes `$JAVA_HOME/conf/accessibility.properties` + copies `libatk-wrapper.so` into `$JAVA_HOME/lib/`.
- `docker/run.sh` drops `start_dbus_session`, `start_atspi`, and the AT-SPI teardown in `stop_ibc`. `matchbox-window-manager` stays — Xvfb still needs a WM for focus routing.
- `gateway_controller.py` drops `-Xbootclasspath/a:/usr/share/java/java-atk-wrapper.jar` from the JVM args. `-Djavax.accessibility.assistive_technologies=` stays in place as defense-in-depth.

**Env-var rename, backwards compatible:** `USE_PYATSPI2_CONTROLLER` → `USE_IBG_CONTROLLER`. The old name is honored as a deprecated alias with a one-line warning at startup so existing `docker-compose.yml` files keep working.

**Docs rewritten** to match: README, MIGRATION, ARCHITECTURE, CONTRIBUTING, UPGRADING, BOOTSTRAP, FROM_IBC, `scripts/install.sh`, `Makefile`, the `GatewayInputAgent.java` javadoc, and the bug-report template. Historical context (the v0.5.12 deadlock, the spike retrospective, the CCP-lockout triage signature) is preserved as labeled history in `ARCHITECTURE.md`, `DISCONNECT_RECOVERY.md`, `ADR-001`, and the README troubleshooting block.

## Followup, intentionally not in this PR

`gateway_controller.py` still imports `gi.repository.Atspi` at module load. Four helpers (`get_states`, `wait_for`, `find_descendant`, `click(node)`) reference `Atspi.*` and have no live callers post-v0.5.12; `_read_text` and `_dump_tree` only run under `CONTROLLER_TEST_MODE=1`. Removing them would let us drop `python3-gi`, `gir1.2-atspi-2.0`, and `at-spi2-core` from the Dockerfile too. Deferred to a separate PR so this one stays focused on the documented user-visible surface.

## Test plan

- [x] `python3 -m unittest discover -s tests` — 224 tests OK locally
- [x] `python3 -m py_compile gateway_controller.py` — OK
- [x] `bash -n docker/run.sh` — OK
- [x] Grep audit: every remaining `at-spi`/`pyatspi`/`AtkWrapper`/`USE_PYATSPI2_CONTROLLER` mention is either the deprecated-alias plumbing, labeled historical context, or the Dockerfile comment explaining the kept-for-import packages.
- [ ] CI green
- [ ] Spike: build the image (`make && docker build -t ibg-controller:v0.5.13-rc .`), run a paper-mode container against a real account, verify it reaches `MONITORING` and `/health` reports `version=0.5.13`.
- [ ] Spike: rerun with `USE_PYATSPI2_CONTROLLER=yes` (no `USE_IBG_CONTROLLER` set) and confirm the deprecation warning fires and the controller starts.