### PR TITLE
v0.5.14 — drop dead AT-SPI helpers + gi/Atspi import + apt packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,12 @@ jobs:
   smoke-test-image:
     runs-on: ubuntu-24.04
     needs: build-and-test
-    # Smoke-test in an environment that matches the shipped image's
-    # runtime layer: python3 plus the gi/Atspi typelib stack the
-    # controller still imports at module load (the AT-SPI runtime path
-    # was retired in v0.5.12 and the bridge install steps in v0.5.13,
-    # but `from gi.repository import Atspi` still happens during
-    # gateway_controller.py import). This catches `import` regressions
-    # against the real gi stack rather than the sys.modules mock the
-    # unit tests use.
+    # Smoke-test that gateway_controller.py imports cleanly on a
+    # vanilla host with only stdlib python3 — no gi/Atspi/ATK
+    # dependencies. The controller used to require the full pyatspi2
+    # stack (retired by v0.5.12 / v0.5.13 / v0.5.14). If anyone
+    # accidentally re-introduces an `import gi` at module load, this
+    # job fails because we don't install python3-gi here.
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -106,18 +104,16 @@ jobs:
           distribution: temurin
           java-version: "17"
 
-      - name: Install build + runtime deps on the runner
-        # The runner is ubuntu-24.04 — the same distro we previously
-        # docker-run'd into for this smoke test. Running the smoke
-        # directly on the runner drops an unreliable hop (docker's
-        # NAT network couldn't reach archive.ubuntu.com on 2026-04-17,
-        # failing the original docker-apt-install flow even though
-        # the runner's own apt was fine).
+      - name: Install build deps on the runner
+        # The runner is ubuntu-24.04 — same distro the shipped image
+        # is built on. We deliberately do NOT install python3-gi /
+        # gir1.2-atspi-2.0 / at-spi2-core: the import smoke test below
+        # must succeed without them (v0.5.14 dropped the gi imports;
+        # this job is the regression guard).
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            make unzip \
-            python3 python3-gi gir1.2-atspi-2.0 at-spi2-core
+            make unzip python3
 
       - name: make
         run: make
@@ -181,10 +177,11 @@ jobs:
             -t ibg-controller:matrix-test .
 
       - name: Container-level module-load smoke test
-        # Verify gateway_controller.py imports cleanly inside the
-        # built image (python3 + gi + Atspi typelib). Catches upstream
-        # base-image drift (missing libs, changed paths) at CI time
-        # rather than at runtime on a user's host.
+        # Verify gateway_controller.py imports cleanly inside the built
+        # image. v0.5.14 dropped the gi/Atspi import, so this should
+        # succeed with stdlib-only python3. Catches upstream base-image
+        # drift (missing libs, changed paths) at CI time rather than at
+        # runtime on a user's host.
         env:
           TWS_USERID: x
           TWS_PASSWORD: x
@@ -254,7 +251,7 @@ jobs:
             fi
             echo "OK assistive_technologies disable flag still in controller"
 
-            # 4. Sanity: the things v0.5.13 KEPT must still be present.
+            # 4. Sanity: the things v0.5.13/v0.5.14 KEPT must still be present.
             test -f /home/ibgateway/gateway-input-agent.jar \
               && echo "OK input agent jar in place"
             test -f /home/ibgateway/scripts/gateway_controller.py \
@@ -263,4 +260,19 @@ jobs:
               && echo "OK run.sh executable in place"
             command -v matchbox-window-manager >/dev/null \
               && echo "OK matchbox-window-manager installed"
+
+            # 5. v0.5.14: the gi/Atspi stack should not be installed
+            #    by OUR Dockerfile. We log dpkg state informationally —
+            #    upstream may ship its own copy (we tolerate that, since
+            #    nothing imports it anymore). The strict regression
+            #    guard for "controller imports without gi" lives in the
+            #    smoke-test-image job, which runs on a vanilla runner
+            #    with no gi packages installed.
+            for pkg in python3-gi gir1.2-atspi-2.0 at-spi2-core; do
+              if dpkg -l "$pkg" 2>/dev/null | grep -q "^ii"; then
+                echo "NOTE: $pkg installed (upstream base — ours does not pull it)"
+              else
+                echo "OK $pkg absent"
+              fi
+            done
           '

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pycache__/
 
 # Local drafts (posts, notes — not shipped)
 drafts/
+
+# Claude Code harness state — local-only, never tracked
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [0.5.14] - 2026-04-28
+
+### Removed
+
+- **Dead AT-SPI tree-walking helpers** in `gateway_controller.py`,
+  along with the `gi.repository.Atspi` import they required.
+  v0.5.12 left these in place as dead code with zero live callers
+  (everything routed through `agent_*`); v0.5.14 deletes them.
+  Specifically:
+  - `find_descendant(node, ...)`, `wait_for(app, role, ...)`,
+    `get_states(node)`, `_dump_tree(node, ...)`, `_read_text(node)`,
+    `set_text(node, text)`, and the `click(node)` AT-SPI overload.
+  - `import gi`, `gi.require_version("Atspi", "2.0")`, and
+    `from gi.repository import Atspi` from the module preamble.
+  - The `_STATE_NAMES`-style `Atspi.StateType.*` mapping inside
+    `get_states` (gone with the function).
+- **The runtime apt install of `python3-gi`, `gir1.2-atspi-2.0`,
+  and `at-spi2-core`** in the `Dockerfile`. These were only kept
+  alive in v0.5.13 because the controller's module-load imports
+  needed the typelib and `libatspi.so.0`. With the imports gone,
+  the runtime layer is now just `python3 matchbox-window-manager
+  curl` on top of the upstream `gnzsnz/ib-gateway` base.
+- The `python3-gi` / `gir1.2-atspi-2.0` / `at-spi2-core` apt install
+  in the `smoke-test-image` CI job. The job's runner is now vanilla
+  python3, and the import succeeding without those packages is the
+  regression guard.
+- The `sys.modules` gi-stack mock in `tests/test_pure_logic.py`
+  (no longer needed; the controller imports cleanly on any host).
+
+### Changed
+
+- `_StubApp` renamed to `_AppHandle`. Old class exposed a full
+  pyatspi-Accessible-like surface (`get_role_name`,
+  `get_state_set`, `get_child_count`, `get_child_at_index`,
+  `get_description`) for the now-deleted tree-walking callers.
+  The new class carries only the two methods callers actually
+  use: `get_name()` and `get_process_id()`. Behavior unchanged.
+- `CONTROLLER_TEST_MODE=1`'s post-Log-In dump switches from
+  `_dump_tree(app)` (which walked the empty AT-SPI tree post-v0.5.12
+  and produced nothing useful) to dumping the live Swing window
+  state via the agent's `WINDOW` command. The dump is finally
+  informative again.
+- `_AppHandle`, `find_app`, `handle_login`, the gateway-version-matrix
+  CI step's comments, and Dockerfile / CONTRIBUTING / MIGRATION /
+  UPGRADING docs all rewritten to reflect post-v0.5.14 reality.
+
+### Validation
+
+- `python3 -m unittest discover -s tests`: 224 tests pass.
+- `python3 -m py_compile gateway_controller.py`: OK.
+- Bash syntax checks pass.
+- Greps confirm zero `Atspi.`, `import gi`, or `gi.require_version`
+  references remain in `gateway_controller.py`.
+
 ## [0.5.13] - 2026-04-28
 
 ### Removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make
 make install DESTDIR=/home/ibgateway
 
 # Create a release tarball
-make release VERSION=0.5.13
+make release VERSION=0.5.14
 ```
 
 Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.
@@ -22,17 +22,21 @@ Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.
 See `docs/ARCHITECTURE.md` for the full list and why each is needed.
 The short version:
 
-- `python3` — runs `gateway_controller.py`
+- `python3` — runs `gateway_controller.py` (stdlib-only at module load
+  as of v0.5.14 — no gi/Atspi/PyGObject required)
 - `matchbox-window-manager` — Xvfb has no WM by default; Gateway's
   input routing depends on a focused window
 
 Pre-v0.5.13 the image also installed `python3-gi gir1.2-atspi-2.0
 at-spi2-core libatk-wrapper-java libatk-wrapper-java-jni dbus-x11` and
-configured `$JAVA_HOME/conf/accessibility.properties`. v0.5.12 disabled
-the AT-SPI bridge in the JVM (it was deadlocking on Swing dispatch);
-v0.5.13 removed the install steps. If you're rebasing from an older
-fork, drop those packages and the JRE accessibility.properties write
-when you bring your image forward.
+configured `$JAVA_HOME/conf/accessibility.properties` for the AT-SPI
+bridge. v0.5.12 disabled the bridge in the JVM (it was deadlocking on
+Swing dispatch); v0.5.13 removed the JVM-side bridge install steps;
+v0.5.14 finished the cleanup by removing the dead Python helpers that
+had kept `python3-gi gir1.2-atspi-2.0 at-spi2-core` alive in the
+apt install. If you're rebasing from an older fork, drop those
+packages and the JRE accessibility.properties write when you bring
+your image forward.
 
 ## Code layout
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,19 +23,13 @@ USER root
 # Runtime packages. `gettext-base socat xvfb x11vnc sshpass openssh-client
 # sudo telnet` are already in the upstream image; listed nowhere here
 # because the upstream provides them. We add:
-#   - python3 + python3-gi + gir1.2-atspi-2.0 + at-spi2-core: the Python
-#     controller still does `from gi.repository import Atspi` at module
-#     load. The AT-SPI bridge is disabled in the JVM (see
-#     gateway_controller.py launch_gateway) and the bus daemons are no
-#     longer started, but the typelib + libatspi.so.0 must be installable
-#     for the import to succeed.
+#   - python3: runs gateway_controller.py.
 #   - matchbox-window-manager: Xvfb has no concept of focused window
 #     without a WM, and Gateway's input routing depends on focus.
 #   - curl: used by scripts/healthcheck.sh.
 RUN apt-get update -y \
  && apt-get install --no-install-recommends --yes \
-      python3 python3-gi gir1.2-atspi-2.0 at-spi2-core \
-      matchbox-window-manager curl \
+      python3 matchbox-window-manager curl \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Version is overridable on the command line:
 #   make release VERSION=0.2.0
 
-VERSION          ?= 0.5.13
+VERSION          ?= 0.5.14
 NAME             := ibg-controller
 DIST             := dist
 AGENT_SRC        := agent/GatewayInputAgent.java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d --name ibkr \
 ```
 
 Tags published: `:latest`, `:<major>.<minor>` (e.g. `:0.5`), and
-`:v<major>.<minor>.<patch>` (e.g. `:v0.5.13`). Every tag is signed with
+`:v<major>.<minor>.<patch>` (e.g. `:v0.5.14`). Every tag is signed with
 cosign via Sigstore keyless signing — see [`SECURITY.md`](SECURITY.md)
 for the verification recipe. For reproducible deployments, pin to a
 digest (`ghcr.io/code-hustler-ft3d/ibg-controller@sha256:...`) — the
@@ -127,7 +127,7 @@ Quick start above instead.
 | **Python 3.10+** | For f-strings with `=` and type hints. |
 | **JDK 17+** | Only at *build* time, for the agent. Runtime uses Gateway's bundled Zulu JRE. |
 | **Ubuntu packages** | `python3 matchbox-window-manager` (matchbox provides focus routing for Xvfb; Xvfb itself ships in the upstream `gnzsnz/ib-gateway` image) |
-| **JRE config** | None. Pre-v0.5.13 the image wrote `accessibility.properties` and copied `libatk-wrapper.so` into the JRE; both were dropped after v0.5.12 disabled the AT-SPI bridge in the JVM. |
+| **JRE config** | None. Pre-v0.5.14 the image wrote `accessibility.properties` and copied `libatk-wrapper.so` into the JRE; both were dropped after v0.5.12 disabled the AT-SPI bridge in the JVM. |
 
 ## Compatibility table
 
@@ -205,9 +205,9 @@ corresponding product.
   clicks. v0.5.12 disabled the bridge in the JVM after a thread-dump
   showed `AtkWrapper$5.propertyChange` deadlocking on
   `JProgressBar.setValue` calls during login (surfaced as a misleading
-  `CCP LOCKOUT DETECTED` warning); v0.5.13 removed the install-time
+  `CCP LOCKOUT DETECTED` warning); v0.5.14 removed the install-time
   ATK packages and JRE configuration entirely. See
-  [CHANGELOG.md](CHANGELOG.md) v0.5.12 / v0.5.13 for the full record.
+  [CHANGELOG.md](CHANGELOG.md) v0.5.12 / v0.5.14 for the full record.
 
 Full diagnostic history and architectural reasoning: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
@@ -391,8 +391,8 @@ make
 # Syntax-check the Python controller + validate the agent jar manifest
 make test
 
-# Create a release tarball (dist/ibg-controller-0.5.13.tar.gz)
-make release VERSION=0.5.13
+# Create a release tarball (dist/ibg-controller-0.5.14.tar.gz)
+make release VERSION=0.5.14
 
 # Install directly into a running ibgateway home (for dev on host, or
 # as called by the Docker image's setup stage)
@@ -404,7 +404,7 @@ Build requires a JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.
 ### Installing from a release tarball (for consumers who don't build)
 
 ```bash
-VER=0.5.13
+VER=0.5.14
 curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${VER}/ibg-controller-${VER}.tar.gz
 tar -xzf ibg-controller-${VER}.tar.gz
 cd ibg-controller-${VER}
@@ -413,7 +413,7 @@ DESTDIR=/home/ibgateway ./install.sh
 
 The tarball layout is flat:
 ```
-ibg-controller-0.5.13/
+ibg-controller-0.5.14/
 ├── gateway-input-agent.jar   ← installed to $DESTDIR/gateway-input-agent.jar
 ├── gateway_controller.py      ← installed to $DESTDIR/scripts/gateway_controller.py
 ├── ibc_config_to_env.py       ← one-shot IBC config.ini → env migration tool
@@ -542,7 +542,7 @@ start. Check:
 > **Pre-v0.5.12 deployments only:** if you're still on a release that
 > used the AT-SPI desktop tree for app discovery and you see "IBKR
 > Gateway never appeared in AT-SPI desktop tree within 120s",
-> upgrade. v0.5.12+ doesn't use AT-SPI at all and v0.5.13 removed the
+> upgrade. v0.5.12+ doesn't use AT-SPI at all and v0.5.14 removed the
 > ATK install steps from the image; both error modes are gone.
 
 ### "Existing session detected" dialog keeps appearing in a loop

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -54,7 +54,8 @@ RUN apt-get update -y && \
 ```
 
 The new runtime packages:
-- `python3` — runs `gateway_controller.py`
+- `python3` — runs `gateway_controller.py` (stdlib-only at module
+  load as of v0.5.14 — no PyGObject/gi/Atspi)
 - `matchbox-window-manager` — a minimal window manager (Xvfb has no
   WM by default and Gateway's input routing depends on a focus owner)
 
@@ -65,9 +66,12 @@ The new runtime packages:
 > the AT-SPI `AtkWrapper` bridge for component discovery. v0.5.12
 > disabled the bridge after it was found to deadlock on
 > `JProgressBar.setValue` calls during login (intra-JVM, not
-> broker-side); v0.5.13 removed the install steps entirely. All UI
-> work now goes through the in-JVM agent socket. If you're rebasing
-> from a fork that has the old install block, drop it.
+> broker-side); v0.5.13 removed the JVM-side install steps; v0.5.14
+> removed the residual `python3-gi gir1.2-atspi-2.0 at-spi2-core`
+> install along with the dead Python helpers that referenced
+> `gi.repository.Atspi`. All UI work now goes through the in-JVM
+> agent socket. If you're rebasing from a fork that has the old
+> install block, drop it.
 
 ## What changes in `run.sh`
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,6 +76,42 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
+### v0.5.14
+
+**No breaking changes.** Finishes the v0.5.13 cleanup by removing the
+dead Python helpers in `gateway_controller.py` that referenced
+`gi.repository.Atspi`, then dropping the apt packages those imports
+required.
+
+- `gateway_controller.py` no longer does `import gi` or
+  `from gi.repository import Atspi` at module load. Removed: the
+  `find_descendant`, `wait_for`, `get_states`, `_dump_tree`,
+  `_read_text`, `set_text(node, ...)`, `click(node)` helpers
+  (zero live callers — all UI work routes through `agent_*` calls).
+  `_StubApp` was renamed to `_AppHandle` and slimmed to the two
+  methods callers actually use (`get_name()`, `get_process_id()`).
+  `CONTROLLER_TEST_MODE=1`'s post-Log-In tree dump now uses the
+  agent's `WINDOW` command instead of the (empty) AT-SPI tree.
+- `Dockerfile` drops `python3-gi`, `gir1.2-atspi-2.0`, and
+  `at-spi2-core` from apt install. The runtime layer is now just
+  `python3 matchbox-window-manager curl` on top of the upstream
+  `gnzsnz/ib-gateway` base.
+- `tests/test_pure_logic.py` no longer needs to mock `gi` /
+  `gi.repository` / `gi.repository.Atspi` in `sys.modules` to load
+  the controller — `python3 gateway_controller.py` works on any host
+  with stdlib.
+- `smoke-test-image` CI job no longer installs `python3-gi`/etc.
+  on the runner; the import succeeding without them is now the
+  regression guard.
+
+**No operator action required for the prebuilt GHCR image** beyond
+the redeploy. Image size shrinks by ~5 MB (the gi/Atspi stack and
+its transitive deps).
+
+If you maintain a fork that still imports `gi.repository.Atspi`
+directly from `gateway_controller.py`, those imports won't be there
+on v0.5.14 — pin to your fork's branch, not `:latest`.
+
 ### v0.5.13
 
 **No breaking changes for image consumers.** Image cleanup — drops

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -48,10 +48,8 @@ from datetime import datetime, time as dtime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from zoneinfo import ZoneInfo
 
-import gi
 
-
-__version__ = "0.5.13"
+__version__ = "0.5.14"
 
 # Wall-clock timestamp recorded when the controller module loads. Reported
 # by the /health endpoint as `uptime_seconds` so monitoring can spot a
@@ -101,8 +99,6 @@ def _set_state(new_state):
     old = _current_state
     _current_state = new_state
     log.info(f"[STATE: {new_state.value}]")
-gi.require_version("Atspi", "2.0")
-from gi.repository import Atspi  # noqa: E402
 
 
 # ── Config from environment ─────────────────────────────────────────────
@@ -292,62 +288,18 @@ def safe(fn, default=None):
     return default
 
 
-def find_descendant(node, role=None, name=None, depth=0, max_depth=20):
-    """Walk a subtree DFS looking for the first node matching role and/or name.
+class _AppHandle:
+    """Lightweight handle representing the controller's identified Gateway JVM.
 
-    Match semantics:
-      - role: exact match against get_role_name()
-      - name: exact match against get_name() OR get_description()
-        (Gateway uses description for icon-only buttons like Close/Min/Max)
-    """
-    if depth > max_depth:
-        return None
-    try:
-        n_role = node.get_role_name()
-    except Exception:
-        n_role = None
-    try:
-        n_name = node.get_name() or ""
-    except Exception:
-        n_name = ""
-    try:
-        n_desc = node.get_description() or ""
-    except Exception:
-        n_desc = ""
-
-    role_ok = role is None or n_role == role
-    name_ok = name is None or n_name == name or n_desc == name
-    if role_ok and name_ok:
-        return node
-
-    n_children = safe(lambda: node.get_child_count(), 0) or 0
-    for i in range(n_children):
-        child = safe(lambda: node.get_child_at_index(i))
-        if child is None:
-            continue
-        hit = find_descendant(child, role=role, name=name,
-                              depth=depth + 1, max_depth=max_depth)
-        if hit is not None:
-            return hit
-    return None
-
-
-class _StubApp:
-    """Stand-in for an AT-SPI Accessible when the bridge is disabled.
-
-    v0.5.12: with ``-Djavax.accessibility.assistive_technologies=`` set on
-    the JVM, the AT-SPI desktop tree never sees a Gateway entry — so
-    pyatspi-based discovery (find_app) would always time out. All
-    login-UI code paths now go through the in-JVM gateway-input-agent
-    socket, which doesn't need the AT-SPI tree.
-
-    The stub keeps a minimal pyatspi-Accessible-like surface so the
-    handful of remaining callsites that still pass ``app`` around (and
-    occasionally call ``app.get_name()`` / ``get_process_id()`` for
-    logging) keep working without per-callsite branching. Tree-walking
-    callers (find_descendant, get_states, _read_text, click(node))
-    treat a zero-child subtree as "nothing matched" and bail
-    gracefully — same behavior they already had under AT-SPI flake.
+    The class predates v0.5.12 — it used to expose a pyatspi-Accessible-like
+    surface (get_role_name/get_state_set/get_child_count/...) so callers
+    could walk the AT-SPI tree off it. v0.5.12 disabled the AT-SPI bridge
+    in the JVM, and v0.5.14 removed the dead tree-walking helpers
+    (find_descendant / wait_for / get_states / _read_text / click(node) /
+    set_text(node, ...) / _dump_tree). The handle now carries only the
+    name + PID — what surviving callers actually use, plus a passthrough
+    argument for legacy signatures (handle_login(app), attempt_reauth(app),
+    do_restart_in_place(app), monitor_loop(app)).
     """
 
     def __init__(self, name="IBKR Gateway", pid=None):
@@ -360,40 +312,27 @@ class _StubApp:
     def get_process_id(self):
         return self._pid
 
-    def get_child_count(self):
-        return 0
-
-    def get_child_at_index(self, i):
-        return None
-
-    def get_role_name(self):
-        return "application"
-
-    def get_description(self):
-        return ""
-
-    def get_state_set(self):
-        return None
-
 
 def find_app(name_substring, timeout=120, match_pid=None):
-    """Return a placeholder application accessible.
+    """Return an app handle carrying the JVM PID reported by the agent.
 
     Pre-v0.5.12 this polled the AT-SPI desktop tree until an entry
-    matching ``name_substring`` appeared — the legacy way of getting an
-    AT-SPI Accessible to feed wait_for/find_descendant. With the AT-SPI
-    bridge disabled (see ``launch_gateway``) the desktop tree never
-    populates, so polling would always time out. We short-circuit to a
-    ``_StubApp`` carrying the JVM's PID so existing callers (which use
-    the return value only for logging and as a passthrough argument to
-    handle_login / attempt_inplace_relogin / etc.) keep working without
-    every callsite having to know that AT-SPI is gone.
+    matching ``name_substring`` appeared. v0.5.12 disabled the AT-SPI
+    bridge in the JVM (``launch_gateway`` passes
+    ``-Djavax.accessibility.assistive_technologies=``), so the desktop
+    tree never populates — polling would always time out. We
+    short-circuit to an ``_AppHandle`` carrying the agent-reported JVM
+    PID so existing callers (which use the return value only for
+    logging and as a passthrough argument to handle_login /
+    attempt_inplace_relogin / etc.) keep working without every callsite
+    having to know that AT-SPI is gone.
 
-    Returns the stub immediately. The ``timeout`` argument is ignored.
-    Returns ``None`` only if the agent's GET_PID never succeeded
-    (agent_get_pid returned None at controller startup), since in that
-    case dual-mode containers can't safely identify "their own" JVM and
-    the caller should treat that as a genuine launch failure.
+    Returns the handle immediately. The ``timeout`` argument is
+    ignored. Returns ``None`` only if the agent's ``GET_PID`` never
+    succeeded (``agent_get_pid`` returned ``None`` at controller
+    startup), since in that case dual-mode containers can't safely
+    identify "their own" JVM and the caller should treat that as a
+    genuine launch failure.
     """
     pid = match_pid if match_pid is not None else JVM_PID
     if pid is None:
@@ -402,46 +341,7 @@ def find_app(name_substring, timeout=120, match_pid=None):
         return None
     name = name_substring if isinstance(name_substring, str) else (
         name_substring[0] if name_substring else "IBKR Gateway")
-    return _StubApp(name=name, pid=pid)
-
-
-def wait_for(app, role, name=None, timeout=60):
-    """Poll the app subtree until a node with role (and optional name) appears."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        node = find_descendant(app, role=role, name=name)
-        if node is not None:
-            return node
-        time.sleep(0.3)
-    return None
-
-
-def get_states(node):
-    """Return the set of state names on a node, e.g. {'focusable', 'checked'}."""
-    state_set = safe(lambda: node.get_state_set())
-    if state_set is None:
-        return set()
-    states = set()
-    # AT-SPI state enum values are 0..N. We probe a known range.
-    state_map = {
-        Atspi.StateType.FOCUSABLE: "focusable",
-        Atspi.StateType.FOCUSED: "focused",
-        Atspi.StateType.EDITABLE: "editable",
-        Atspi.StateType.SHOWING: "showing",
-        Atspi.StateType.VISIBLE: "visible",
-        Atspi.StateType.ENABLED: "enabled",
-        Atspi.StateType.SENSITIVE: "sensitive",
-        Atspi.StateType.SELECTED: "selected",
-        Atspi.StateType.CHECKED: "checked",
-        Atspi.StateType.PRESSED: "pressed",
-    }
-    for st, label in state_map.items():
-        try:
-            if state_set.contains(st):
-                states.add(label)
-        except Exception:
-            pass
-    return states
+    return _AppHandle(name=name, pid=pid)
 
 
 # ── In-JVM agent client ─────────────────────────────────────────────────
@@ -830,93 +730,6 @@ def agent_window(title_substring=""):
     return _agent_multiline(f"WINDOW {title_substring}", timeout=10)
 
 
-def _dump_tree(node, depth=0, max_depth=15):
-    """Diagnostic-only — dump a subtree to the log."""
-    if depth > max_depth * 2:
-        return
-    role = safe(lambda: node.get_role_name(), "?")
-    name = safe(lambda: node.get_name(), "") or ""
-    desc = safe(lambda: node.get_description(), "") or ""
-    parts = [role]
-    if name: parts.append(f'name={name!r}')
-    if desc: parts.append(f'desc={desc!r}')
-    txt = _read_text(node)
-    if txt: parts.append(f'text={txt!r}')
-    log.info(" " * depth + " ".join(parts))
-    n = safe(lambda: node.get_child_count(), 0) or 0
-    for i in range(n):
-        c = safe(lambda: node.get_child_at_index(i))
-        if c is not None:
-            _dump_tree(c, depth + 2, max_depth)
-
-
-def _read_text(node):
-    """Read the current contents of a text node via the Text interface."""
-    try:
-        n_chars = Atspi.Text.get_character_count(node)
-        if n_chars <= 0:
-            return ""
-        return Atspi.Text.get_text(node, 0, n_chars) or ""
-    except Exception:
-        return ""
-
-
-def set_text(node, text):
-    """Set text on an editable node by delegating to the in-JVM agent.
-
-    External text input (AT-SPI EditableText, xdotool XTest, XSendEvent)
-    all fail against Gateway's hardened login form. Phase 1 spike proved
-    that only in-JVM JTextField.setText() reaches the field. The agent
-    runs inside Gateway's JVM (loaded via -javaagent:) and exposes the
-    operation over a Unix socket. See spike/PHASE1_FINDINGS.md for the
-    full diagnostic story.
-
-    The agent looks up components by AccessibleContext.getAccessibleName(),
-    which is the same name AT-SPI exposes — so the AT-SPI node we found
-    via Python and the Java component the agent finds are the same object.
-    """
-    role = safe(lambda: node.get_role_name(), "?")
-    is_password = role == "password text"
-    name = safe(lambda: node.get_name(), "") or ""
-
-    if not name:
-        log.error(f"set_text on {role}: node has no accessible name — can't dispatch to agent")
-        return False
-
-    if not agent_settext(name, text):
-        return False
-
-    # Verify (skip for passwords — readback is masked anyway).
-    if is_password:
-        log.info(f"set_text on {role} {name!r}: ok via agent (verify skipped — masked)")
-        return True
-
-    actual = agent_gettext(name)
-    if actual == text:
-        log.info(f"set_text on {role} {name!r}: ok via agent (verified)")
-        return True
-    log.warning(f"set_text on {role} {name!r}: agent reported OK but readback was {actual!r}")
-    # Trust the agent's OK over the readback — the agent is more reliable.
-    return True
-
-
-def click(node):
-    """Perform the default action (action 0) on a node. For buttons this is 'click'."""
-    role = safe(lambda: node.get_role_name(), "?")
-    name = safe(lambda: node.get_name(), "") or ""
-    try:
-        n_actions = safe(lambda: Atspi.Action.get_n_actions(node), 0) or 0
-        if n_actions == 0:
-            log.error(f"click on {role}:{name!r}: no actions exposed")
-            return False
-        ok = Atspi.Action.do_action(node, 0)
-        log.info(f"click on {role}:{name!r}: {'ok' if ok else 'failed'}")
-        return ok
-    except Exception as e:
-        log.error(f"click on {role}:{name!r}: {e}")
-        return False
-
-
 # ── Gateway launch ──────────────────────────────────────────────────────
 
 def find_gateway_launcher():
@@ -1281,12 +1094,12 @@ def handle_login(app):
     disabled in the JVM (see ``launch_gateway`` — the
     ``-Djavax.accessibility.assistive_technologies=`` flag) to prevent the
     AtkWrapper$5.propertyChange + AtkUtil.invokeInSwing deadlock that hung
-    JTS-Login-14 during the welcome-screen JProgressBar update. Without
-    AT-SPI, ``find_app`` / ``find_descendant`` / ``wait_for`` /
-    ``get_states`` / ``click(node)`` / ``_read_text`` no longer have a
-    populated tree to walk, so all login-UI interaction goes through the
-    in-JVM ``gateway-input-agent`` socket — pure Swing/AWT, no AT-SPI
-    callbacks, no JNI re-entrancy, no deadlock.
+    JTS-Login-14 during the welcome-screen JProgressBar update. v0.5.14
+    physically removed the dead helpers (find_descendant / wait_for /
+    get_states / click(node) / _read_text / set_text(node, ...) /
+    _dump_tree) and the gi.repository.Atspi import. All login-UI
+    interaction goes through the in-JVM ``gateway-input-agent`` socket —
+    pure Swing/AWT, no AT-SPI callbacks, no JNI re-entrancy, no deadlock.
 
     The ``app`` argument is now a placeholder kept only for caller
     compatibility (attempt_inplace_relogin, do_restart_in_place,
@@ -3423,10 +3236,15 @@ def main():
         sys.exit(1)
 
     if TEST_MODE:
-        log.info("CONTROLLER_TEST_MODE=1 — waiting 5s for Gateway response then dumping tree")
+        log.info("CONTROLLER_TEST_MODE=1 — waiting 5s for Gateway response then dumping window state")
         time.sleep(5)
-        log.info("=== POST-CLICK TREE DUMP ===")
-        _dump_tree(app, max_depth=15)
+        log.info("=== POST-CLICK WINDOW DUMP (via agent) ===")
+        try:
+            for line in agent_window("").split("\n"):
+                if line and line not in ("OK", "END"):
+                    log.info(f"  {line}")
+        except Exception as e:
+            log.error(f"  agent_window dump failed: {type(e).__name__}: {e}")
         sys.exit(0)
 
     # 3a. Check for CCP lockout BEFORE entering the 2FA wait. Gateway's

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # running ibgateway container's filesystem.
 #
 # Usage (from the docker image's setup stage):
-#   ARG IBG_CONTROLLER_VERSION=0.5.13
+#   ARG IBG_CONTROLLER_VERSION=0.5.14
 #   RUN curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${IBG_CONTROLLER_VERSION}/ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       tar -xzf ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       cd ibg-controller-${IBG_CONTROLLER_VERSION} && \

--- a/tests/test_pure_logic.py
+++ b/tests/test_pure_logic.py
@@ -1,16 +1,10 @@
 """Pure-Python unit tests for gateway_controller.py helpers.
 
-No network, no filesystem side effects, no AT-SPI. Run with:
+No network, no filesystem side effects. Run with:
 
     python3 -m unittest discover -s tests -v
 
 or via `make test` (which gates on unittest discover).
-
-These tests import gateway_controller.py directly with the `gi` and
-`gi.repository.Atspi` modules mocked in sys.modules so the real
-pyatspi2 stack isn't required on the test host. That lets `make test`
-pass in a minimal build container (eclipse-temurin:17-jdk + python3,
-no GTK, no ATK).
 
 What's covered:
   - _validate_hostname: accept DNS-label strings, reject whitespace /
@@ -26,7 +20,6 @@ What's covered:
 What's NOT covered by this file (tracked separately):
   - jts.ini writer (side effects on filesystem — needs tempdir fixture)
   - Agent protocol client (needs a mock socket server)
-  - AT-SPI code paths (need the full gi stack)
   - Live login flow (needs real Gateway + real credentials)
 """
 
@@ -38,17 +31,18 @@ from unittest.mock import MagicMock, patch
 
 
 def _load_module():
-    """Load gateway_controller.py with the pyatspi2 stack stubbed out.
+    """Load gateway_controller.py from the repo root.
 
     Returns the module object, reusable across tests. Called once at
     import time and cached at module level so each TestCase doesn't
     pay the startup cost.
-    """
-    # Stub the gi / gi.repository / gi.repository.Atspi imports.
-    sys.modules.setdefault("gi", MagicMock())
-    sys.modules.setdefault("gi.repository", MagicMock())
-    sys.modules.setdefault("gi.repository.Atspi", MagicMock())
 
+    v0.5.14: the controller no longer imports gi.repository.Atspi at
+    module load (the dead AT-SPI tree-walking helpers were removed
+    along with the package install in the Dockerfile), so this loader
+    no longer needs to stub the gi stack in sys.modules. A bare
+    ``python3 gateway_controller.py`` works on any host with stdlib.
+    """
     # The module does os.environ.get for several vars at load time;
     # most are optional but the controller checks USERNAME/PASSWORD
     # only inside main(), so we don't need to set them.


### PR DESCRIPTION
## Summary

The followup deferred from v0.5.13 / issue #1.

v0.5.12 disabled the AT-SPI bridge in the JVM and routed all UI work through the in-JVM agent socket. v0.5.13 dropped the JRE accessibility-bridge configuration and the `libatk-wrapper-java*` / `dbus-x11` packages. v0.5.14 finishes the cleanup by removing the dead Python helpers that still referenced `gi.repository.Atspi`, then dropping the apt packages those imports required.

## Why now

Right now the codebase has a residual contradiction with its own docs. The README says "no AT-SPI / ATK in the runtime path"; `gateway_controller.py` opens with `import gi` / `from gi.repository import Atspi`; the `Dockerfile` carries a comment explaining we install three apt packages *just because the dead imports demand it*. That's the same flavor of divergence issue #1 was about — finishing it here makes the codebase honest.

## What's removed

- `gateway_controller.py` module preamble: `import gi`, `gi.require_version("Atspi", "2.0")`, `from gi.repository import Atspi`.
- Dead helpers — verified by static grep against every callsite (zero live callers), and confirmed safe by the fact that v0.5.12 has been running in production with these as dead code:
  - `find_descendant(node, ...)` — only `wait_for` called it; `wait_for` is dead too.
  - `wait_for(app, role, ...)` — zero callers anywhere (only docstring/comment mentions).
  - `get_states(node)` — zero callers anywhere.
  - `_dump_tree(node, ...)` — only the `CONTROLLER_TEST_MODE=1` block called it; refactored to use the agent's `WINDOW` command instead.
  - `_read_text(node)` — only `_dump_tree` called it.
  - `set_text(node, text)` — zero callers (all text input goes through `agent_settext_login_user` / `agent_settext_in_window` / etc.).
  - `click(node)` AT-SPI overload — zero callers (every `click(...)` callsite is `agent_click(...)`).
- `Dockerfile` apt install: `python3-gi`, `gir1.2-atspi-2.0`, `at-spi2-core`. Runtime layer is now just `python3 matchbox-window-manager curl` on top of the upstream base.
- `smoke-test-image` CI job's matching apt install on the runner — vanilla python3 succeeding to import the controller is now the regression guard.
- `tests/test_pure_logic.py`'s `sys.modules` gi-stack mock — the controller imports cleanly without it.

## What's renamed / refactored

- `_StubApp` → `_AppHandle`, slimmed to just `get_name()` and `get_process_id()` — the only methods actual callers use. The wider pyatspi-Accessible-like surface (`get_role_name`, `get_state_set`, `get_child_count`, etc.) was only there for the deleted tree-walking helpers.
- `CONTROLLER_TEST_MODE=1` post-Log-In dump: was `_dump_tree(app)` walking the empty AT-SPI tree (produced nothing post-v0.5.12). Now uses `agent_window("")` for a useful diagnostic.
- The `gateway-version-matrix` regression-guard step adds an informational `dpkg -l` check for the three packages — informational because the upstream base may ship them and we tolerate that (the strict guard is in `smoke-test-image`).

## Validation

- [x] `python3 -m unittest discover -s tests` — 224 tests pass (one fewer mock setup line, same coverage)
- [x] `python3 -m py_compile gateway_controller.py` — OK
- [x] `bash -n` on `docker/run.sh`, `scripts/healthcheck.sh`, `scripts/install.sh` — OK
- [x] `ruby -ryaml -e 'YAML.load_file(...)'` on `.github/workflows/ci.yml` — OK
- [x] Greps confirm zero `Atspi.`, `import gi`, or `gi.require_version` remain anywhere
- [ ] CI green
- [ ] Spike: build image (`make && docker build -t ibg-controller:v0.5.14-rc .`), run paper-mode container against a real account, verify `MONITORING` reached and `/health` reports `version=0.5.14`
- [ ] Image size delta visible on the GHCR push (~5 MB shrink expected from dropping the gi/Atspi/at-spi2-core stack and its transitive deps)

## Risk

The only real risk is "did I miss a caller?" Mitigations:

1. Static grep for every dead helper turned up zero live callers (vs. the docstring mentions, which I confirmed manually).
2. v0.5.12 has been running in production with all of these as dead code. If they were reachable, `_StubApp` returning 0 children would already break things — production behavior says they're not reached.
3. `make test`'s 224 unit tests pass with no test changes (other than removing an unnecessary mock).
4. The matrix CI's container-level module-load smoke test imports `gateway_controller` inside the freshly-built image. Any regression caught at CI time.

Net: -84 lines across 12 files. `gateway_controller.py` shrinks by ~150 lines.

Refs #1.