### PR TITLE
v0.6.1 — dual-mode log attribution + post-login config diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,72 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [0.6.1] - 2026-05-01
+
+### Fixed (diagnostic)
+
+- **Dual-mode log attribution.** Pre-v0.6.1 the controller's log
+  format was `<time> [<LEVEL>] <message>` with no mode marker. In
+  dual mode (`TRADING_MODE=both`) two controller processes — one
+  `live`, one `paper` — both write to the same container stdout,
+  so `docker logs <container>` interleaved their lines with no way
+  to tell them apart. Reports like 2026-05-01's "post-login config
+  ran for paper but not live" were impossible to confirm or refute
+  from logs alone. The format is now
+  `<time> [<LEVEL>] [<mode>] <message>`. The mode is fixed at
+  controller-process startup (TRADING_MODE doesn't change for the
+  life of a controller), so this is a per-process baked prefix —
+  no per-call overhead.
+
+  In single-mode runs the prefix is `[live]` or `[paper]` —
+  informative but non-noisy. In dual-mode it makes log streams
+  decisively attributable.
+
+  Note for monitoring consumers: any log-grep that anchors strictly
+  on `^<timestamp> [<LEVEL>] <token>` (the regex starts at the
+  level bracket and expects the token immediately after) will need
+  to accommodate the new `[<mode>] ` segment between them. Greps
+  that match on `ALERT_*` tokens elsewhere in the line are
+  unaffected — the ALERT tokens themselves already include
+  `mode=<value>` per `OBSERVABILITY.md`'s grep-contract.
+
+- **`handle_post_login_config()` now logs the env-var values it
+  observed, on both the apply and the skip paths.** Pre-v0.6.1
+  the function emitted only `"Post-login config: no supported
+  env vars set, skipping"` on the early-return — silent on
+  exactly which env vars were empty. With dual-mode log
+  attribution above, a single new diagnostic line tells you
+  precisely what the controller saw:
+
+  ```
+  HH:MM:SS [INFO] [live] Post-login config env:
+    TWS_MASTER_CLIENT_ID='', READ_ONLY_API='no' (coerced=False),
+    AUTO_LOGOFF_TIME='', AUTO_RESTART_TIME=''
+  ```
+
+  These knobs are not secrets (they're IBC-equivalent post-login
+  API settings) so logging the values is safe.
+
+### Why a diagnostic-only patch and not a fix
+
+The 2026-05-01 bug report ("paper sets Read-Only API = False but
+live silently skips") fits two scenarios that pre-v0.6.1 logs
+couldn't distinguish: (a) a real env-var transmission failure to
+the live controller, or (b) misattribution of two interleaved
+dual-mode log streams. v0.6.1's mode prefix + env-var dump
+discriminates between them on the next reproduction. If (a) is
+real, the next dual-mode log will show
+`[live] Post-login config env: ... READ_ONLY_API='' ...` —
+smoking gun. If (b), both `[live]` and `[paper]` lines will show
+the same env values and the report dissolves.
+
+### Validation
+
+- 224 unit tests pass (no test changes).
+- `python3 -m py_compile gateway_controller.py`: OK.
+- Module-load smoke test: format string interpolates TRADING_MODE
+  cleanly at startup; no per-message overhead.
+
 ## [0.6.0] - 2026-05-01
 
 ### Removed (breaking)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make
 make install DESTDIR=/home/ibgateway
 
 # Create a release tarball
-make release VERSION=0.6.0
+make release VERSION=0.6.1
 ```
 
 Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Version is overridable on the command line:
 #   make release VERSION=0.2.0
 
-VERSION          ?= 0.6.0
+VERSION          ?= 0.6.1
 NAME             := ibg-controller
 DIST             := dist
 AGENT_SRC        := agent/GatewayInputAgent.java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d --name ibkr \
 ```
 
 Tags published: `:latest`, `:<major>.<minor>` (e.g. `:0.5`), and
-`:v<major>.<minor>.<patch>` (e.g. `:v0.6.0`). Every tag is signed with
+`:v<major>.<minor>.<patch>` (e.g. `:v0.6.1`). Every tag is signed with
 cosign via Sigstore keyless signing — see [`SECURITY.md`](SECURITY.md)
 for the verification recipe. For reproducible deployments, pin to a
 digest (`ghcr.io/code-hustler-ft3d/ibg-controller@sha256:...`) — the
@@ -127,7 +127,7 @@ Quick start above instead.
 | **Python 3.10+** | For f-strings with `=` and type hints. |
 | **JDK 17+** | Only at *build* time, for the agent. Runtime uses Gateway's bundled Zulu JRE. |
 | **Ubuntu packages** | `python3 matchbox-window-manager` (matchbox provides focus routing for Xvfb; Xvfb itself ships in the upstream `gnzsnz/ib-gateway` image) |
-| **JRE config** | None. Pre-v0.6.0 the image wrote `accessibility.properties` and copied `libatk-wrapper.so` into the JRE; both were dropped after v0.5.12 disabled the AT-SPI bridge in the JVM. |
+| **JRE config** | None. Pre-v0.6.1 the image wrote `accessibility.properties` and copied `libatk-wrapper.so` into the JRE; both were dropped after v0.5.12 disabled the AT-SPI bridge in the JVM. |
 
 ## Compatibility table
 
@@ -205,9 +205,9 @@ corresponding product.
   clicks. v0.5.12 disabled the bridge in the JVM after a thread-dump
   showed `AtkWrapper$5.propertyChange` deadlocking on
   `JProgressBar.setValue` calls during login (surfaced as a misleading
-  `CCP LOCKOUT DETECTED` warning); v0.6.0 removed the install-time
+  `CCP LOCKOUT DETECTED` warning); v0.6.1 removed the install-time
   ATK packages and JRE configuration entirely. See
-  [CHANGELOG.md](CHANGELOG.md) v0.5.12 / v0.6.0 for the full record.
+  [CHANGELOG.md](CHANGELOG.md) v0.5.12 / v0.6.1 for the full record.
 
 Full diagnostic history and architectural reasoning: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
@@ -391,8 +391,8 @@ make
 # Syntax-check the Python controller + validate the agent jar manifest
 make test
 
-# Create a release tarball (dist/ibg-controller-0.6.0.tar.gz)
-make release VERSION=0.6.0
+# Create a release tarball (dist/ibg-controller-0.6.1.tar.gz)
+make release VERSION=0.6.1
 
 # Install directly into a running ibgateway home (for dev on host, or
 # as called by the Docker image's setup stage)
@@ -404,7 +404,7 @@ Build requires a JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.
 ### Installing from a release tarball (for consumers who don't build)
 
 ```bash
-VER=0.6.0
+VER=0.6.1
 curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${VER}/ibg-controller-${VER}.tar.gz
 tar -xzf ibg-controller-${VER}.tar.gz
 cd ibg-controller-${VER}
@@ -413,7 +413,7 @@ DESTDIR=/home/ibgateway ./install.sh
 
 The tarball layout is flat:
 ```
-ibg-controller-0.6.0/
+ibg-controller-0.6.1/
 ├── gateway-input-agent.jar   ← installed to $DESTDIR/gateway-input-agent.jar
 ├── gateway_controller.py      ← installed to $DESTDIR/scripts/gateway_controller.py
 ├── ibc_config_to_env.py       ← one-shot IBC config.ini → env migration tool
@@ -542,7 +542,7 @@ start. Check:
 > **Pre-v0.5.12 deployments only:** if you're still on a release that
 > used the AT-SPI desktop tree for app discovery and you see "IBKR
 > Gateway never appeared in AT-SPI desktop tree within 120s",
-> upgrade. v0.5.12+ doesn't use AT-SPI at all and v0.6.0 removed the
+> upgrade. v0.5.12+ doesn't use AT-SPI at all and v0.6.1 removed the
 > ATK install steps from the image; both error modes are gone.
 
 ### "Existing session detected" dialog keeps appearing in a loop

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,6 +76,38 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
+### v0.6.1
+
+**No breaking changes.** Operational improvement for dual-mode
+deployments: every log line now carries a `[live]` or `[paper]`
+prefix so dual-mode containers' interleaved stdout in
+`docker logs <container>` is finally attributable.
+
+The new format is:
+
+```
+<timestamp> [<LEVEL>] [<mode>] <message>
+```
+
+In single-mode (`TRADING_MODE=live` or `TRADING_MODE=paper`) the
+prefix is informative but non-noisy. In dual-mode
+(`TRADING_MODE=both`) it lets you tell `[live]` and `[paper]` lines
+apart at a glance.
+
+`handle_post_login_config()` also logs the env-var values it
+observed (on both the apply and the skip paths) so it's now
+explicit which knobs each controller saw vs. perceived as empty.
+Useful for diagnosing env-transmission bugs in compose / Docker
+secrets / orchestrator setups.
+
+**Action for monitoring consumers:** any log-grep that anchors
+strictly on the level bracket plus the next token (e.g.
+`^[0-9:]+ \[INFO\] (Applying|Post-login)`) needs to accommodate the
+new `[<mode>] ` segment between them. Greps that match
+`ALERT_*` tokens elsewhere in the line are unaffected — the
+ALERT tokens already include `mode=<value>` per
+[OBSERVABILITY.md](OBSERVABILITY.md)'s grep-contract.
+
 ### v0.6.0
 
 **Breaking change for anyone still on the `USE_PYATSPI2_CONTROLLER`

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -49,7 +49,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from zoneinfo import ZoneInfo
 
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 # Wall-clock timestamp recorded when the controller module loads. Reported
 # by the /health endpoint as `uptime_seconds` so monitoring can spot a
@@ -255,10 +255,22 @@ else:
 
 
 # ── Logging ─────────────────────────────────────────────────────────────
+#
+# v0.6.1: include TRADING_MODE as a fixed prefix on every log line. In
+# dual mode (TRADING_MODE=both, which run.sh splits into two parallel
+# controller processes — one "live", one "paper") both controllers'
+# stdout interleaves into the same `docker logs <container>` stream
+# with no way to tell their lines apart. That made bug reports like
+# 2026-05-01's "post-login config skipped for live but ran for paper"
+# impossible to diagnose from logs alone (pre-v0.6.1 the reporter had
+# to pair `[STATE: CONFIG]` lines with subsequent context to guess
+# which controller emitted them). The mode prefix is fixed at module
+# load — TRADING_MODE doesn't change for the life of a controller
+# process, so f-string interpolation here is correct.
 
 logging.basicConfig(
     level=logging.DEBUG if os.environ.get("CONTROLLER_DEBUG") else logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
+    format=f"%(asctime)s [%(levelname)s] [{TRADING_MODE}] %(message)s",
     datefmt="%H:%M:%S",
 )
 log = logging.getLogger("controller")
@@ -1885,7 +1897,8 @@ def handle_post_login_config():
     a working API port even if one setting couldn't be applied.
     """
     master_client_id = os.environ.get("TWS_MASTER_CLIENT_ID", "").strip()
-    read_only_api = _coerce_yes_no(os.environ.get("READ_ONLY_API", ""))
+    read_only_api_raw = os.environ.get("READ_ONLY_API", "")
+    read_only_api = _coerce_yes_no(read_only_api_raw)
     auto_logoff_time = os.environ.get("AUTO_LOGOFF_TIME", "").strip()
     auto_restart_time = os.environ.get("AUTO_RESTART_TIME", "").strip()
     # Truly TWS-only — not present in any Gateway config state we've observed
@@ -1907,6 +1920,20 @@ def handle_post_login_config():
                     f"Gateway's config dialog and are being ignored: "
                     f"{', '.join(tws_only_set)}. They're TWS-specific. "
                     "See controller/docs/MIGRATION.md for details.")
+
+    # v0.6.1: dump exactly what we observed in os.environ on both the
+    # apply and the skip paths. Pre-v0.6.1 a "no supported env vars
+    # set, skipping" line gave no clue whether the user had genuinely
+    # set nothing or whether the env transmission chain (Docker
+    # --env-file → run.sh → start_controller → python3 fork) had
+    # dropped a value somewhere along the way. The values logged here
+    # are not secrets — IBC-equivalent post-login config knobs only.
+    log.info(
+        f"Post-login config env: TWS_MASTER_CLIENT_ID={master_client_id!r}, "
+        f"READ_ONLY_API={read_only_api_raw!r} (coerced={read_only_api!r}), "
+        f"AUTO_LOGOFF_TIME={auto_logoff_time!r}, "
+        f"AUTO_RESTART_TIME={auto_restart_time!r}"
+    )
 
     if not wanted_anything:
         log.info("Post-login config: no supported env vars set, skipping")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # running ibgateway container's filesystem.
 #
 # Usage (from the docker image's setup stage):
-#   ARG IBG_CONTROLLER_VERSION=0.6.0
+#   ARG IBG_CONTROLLER_VERSION=0.6.1
 #   RUN curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${IBG_CONTROLLER_VERSION}/ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       tar -xzf ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       cd ibg-controller-${IBG_CONTROLLER_VERSION} && \


### PR DESCRIPTION
## Summary

Diagnostic-first fix for the 2026-05-01 bug report: "in dual-mode, `handle_post_login_config()` runs for paper but is skipped (silently) for live."

## Reasoning

`handle_post_login_config()` has **zero `TRADING_MODE` branching internally** — verified by grep. The function is called unconditionally in both flows. The upstream `gnzsnz/ib-gateway` `common.sh`'s `apply_settings` doesn't touch the relevant env vars either (only conditionally unsets `TWS_PASSWORD`).

So the symptoms can fit two scenarios:

**(a) Real env-transmission bug.** Live's Python process doesn't see `READ_ONLY_API` in `os.environ` for some reason — the function early-returns at line 1911-1913 with the existing one-line "no supported env vars set, skipping" log, which the reporter overlooks or filters.

**(b) Misattribution.** Both controllers run the apply path normally, but the dual-mode log format had **no mode marker** — so two interleaved controller stdouts in `docker logs <container>` couldn't be told apart, and the reporter inferred "live skipped" from a chain of `[STATE: CONFIG] → [STATE: MONITORING]` adjacency without a way to confirm which mode emitted which line.

`docker exec ... printenv READ_ONLY_API` shows the *container* env, not what's actually in the controller process's `/proc/<pid>/environ`. Pre-v0.6.1, both scenarios produced indistinguishable `docker logs` output.

## Fix

1. **Log format gains a fixed `[<mode>]` prefix** baked at `logging.basicConfig` time via f-string interpolation of `TRADING_MODE`. Per-process, zero per-message overhead. Format becomes `<timestamp> [<LEVEL>] [<mode>] <message>`.

2. **`handle_post_login_config` logs the env-var values it observed**, on both the apply *and* skip paths. The previous "no supported env vars set, skipping" gave no clue which knobs were empty; now it emits an explicit dump every time:
   ```
   HH:MM:SS [INFO] [live] Post-login config env: TWS_MASTER_CLIENT_ID='',
     READ_ONLY_API='no' (coerced=False), AUTO_LOGOFF_TIME='', AUTO_RESTART_TIME=''
   ```
   These knobs are IBC-equivalent post-login API settings — not secrets — so values are safe to log.

## What this fix achieves

On the next dual-mode reproduction with `READ_ONLY_API=no` set:

- **If scenario (a) is real:** `[live] Post-login config env: ... READ_ONLY_API='' ...` shows up. Smoking gun pointing at the env-transmission chain (Docker `--env-file` → `run.sh` → `start_controller` → `python3` fork).
- **If scenario (b):** Both `[live] Post-login config env:` and `[paper] Post-login config env:` lines show the same `READ_ONLY_API='no'` value, both show "Applying post-login configuration from env vars", and the original report dissolves.

Either way, the user gets a definitive answer on the next reproduction, and dual-mode operability improves permanently.

## Note for monitoring consumers

Log-greps that strictly anchor on the level bracket plus the next token (e.g. `^[0-9:]+ \[INFO\] (Applying|Post-login)`) need to accommodate the new `[<mode>] ` segment between them. Greps that match `ALERT_*` tokens are unaffected — those already carry `mode=<value>` per `OBSERVABILITY.md`'s grep-contract.

## Test plan

- [x] `python3 -m unittest discover -s tests` — 224 tests pass (no test changes; test fixture's `TRADING_MODE=paper` sets the format prefix cleanly at module load)
- [x] `python3 -m py_compile gateway_controller.py` — OK
- [x] `bash -n docker/run.sh` — OK
- [x] Manual smoke: log lines now emit `HH:MM:SS [INFO] [live] <message>`
- [ ] CI green
- [ ] Spike: dual-mode container with `READ_ONLY_API=no` set; both `[live]` and `[paper]` lines visible and attributable in `docker logs`