### PR TITLE
v0.6.2 — fix dual-mode _config_open() race after 2FA tear-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [0.6.2] - 2026-05-01
+
+### Fixed
+
+- **Dual-mode `_config_open()` race that silently broke post-login
+  config on live but not paper.** v0.6.1's diagnostic logging
+  revealed the actual failure mode (neither scenario (a)
+  env-transmission nor scenario (b) log-attribution from the
+  original report — a third scenario (c)): live mode transitions
+  `API_WAIT → CONFIG` within ~3 s of the API port opening, with the
+  EDT still processing post-2FA tear-down. The `agent CLICK
+  'Configure'` succeeded (the JMenu's selected property flipped) but
+  by the time the follow-up `agent CLICK 'Settings'` walked
+  `Window.getWindows()`, the `JPopupMenu`'s heavyweight peer window
+  hadn't been realized yet. The agent reported
+  `ERR not_found type=button name=Settings` and post-login config
+  silently failed for live (not paper, which skips 2FA and hits the
+  same code path with a quiescent EDT).
+
+  Three changes in `_config_open()`:
+
+  1. **Wait for the post-login window stack to settle** before
+     clicking `Configure` — no modal dialogs visible, no
+     `Authenticating...` window present. Bounded at 5 s; logs and
+     proceeds anyway if Gateway is showing a different transitional
+     window we haven't explicitly named.
+  2. **Inter-click delay between Configure and Settings raised
+     from 0.3 s to 1.0 s.** That's the time the EDT needs to
+     realize the `JPopupMenu`'s heavyweight peer window when it's
+     coming out of a busy state. Empirically 0.3 s was enough on a
+     quiescent EDT (paper) and not enough on a busy one (live
+     post-2FA).
+  3. **Outer retry loop** — up to 3 attempts to open the dialog,
+     1 s between attempts. Backstop for any other transient that
+     hasn't shown up in the logs yet.
+
+  Net cost on the success path is ~1 s (the longer inter-click
+  delay; the window-settle wait returns immediately when already
+  settled). For the failing case, post-login config now applies on
+  live in dual-mode runs.
+
+### Validation
+
+- 224 unit tests pass (no test changes — the `_config_open` retry
+  logic is at the agent-socket boundary, exercised by integration
+  not unit tests).
+- `python3 -m py_compile gateway_controller.py`: OK.
+- The repro setup from the original bug report
+  (`TWS_USERID + TWS_USERID_PAPER + READ_ONLY_API=no` in dual mode)
+  is the spike target for confirming the live-mode fix lands.
+
 ## [0.6.1] - 2026-05-01
 
 ### Fixed (diagnostic)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make
 make install DESTDIR=/home/ibgateway
 
 # Create a release tarball
-make release VERSION=0.6.1
+make release VERSION=0.6.2
 ```
 
 Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Version is overridable on the command line:
 #   make release VERSION=0.2.0
 
-VERSION          ?= 0.6.1
+VERSION          ?= 0.6.2
 NAME             := ibg-controller
 DIST             := dist
 AGENT_SRC        := agent/GatewayInputAgent.java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d --name ibkr \
 ```
 
 Tags published: `:latest`, `:<major>.<minor>` (e.g. `:0.5`), and
-`:v<major>.<minor>.<patch>` (e.g. `:v0.6.1`). Every tag is signed with
+`:v<major>.<minor>.<patch>` (e.g. `:v0.6.2`). Every tag is signed with
 cosign via Sigstore keyless signing — see [`SECURITY.md`](SECURITY.md)
 for the verification recipe. For reproducible deployments, pin to a
 digest (`ghcr.io/code-hustler-ft3d/ibg-controller@sha256:...`) — the
@@ -127,7 +127,7 @@ Quick start above instead.
 | **Python 3.10+** | For f-strings with `=` and type hints. |
 | **JDK 17+** | Only at *build* time, for the agent. Runtime uses Gateway's bundled Zulu JRE. |
 | **Ubuntu packages** | `python3 matchbox-window-manager` (matchbox provides focus routing for Xvfb; Xvfb itself ships in the upstream `gnzsnz/ib-gateway` image) |
-| **JRE config** | None. Pre-v0.6.1 the image wrote `accessibility.properties` and copied `libatk-wrapper.so` into the JRE; both were dropped after v0.5.12 disabled the AT-SPI bridge in the JVM. |
+| **JRE config** | None. Pre-v0.6.2 the image wrote `accessibility.properties` and copied `libatk-wrapper.so` into the JRE; both were dropped after v0.5.12 disabled the AT-SPI bridge in the JVM. |
 
 ## Compatibility table
 
@@ -205,9 +205,9 @@ corresponding product.
   clicks. v0.5.12 disabled the bridge in the JVM after a thread-dump
   showed `AtkWrapper$5.propertyChange` deadlocking on
   `JProgressBar.setValue` calls during login (surfaced as a misleading
-  `CCP LOCKOUT DETECTED` warning); v0.6.1 removed the install-time
+  `CCP LOCKOUT DETECTED` warning); v0.6.2 removed the install-time
   ATK packages and JRE configuration entirely. See
-  [CHANGELOG.md](CHANGELOG.md) v0.5.12 / v0.6.1 for the full record.
+  [CHANGELOG.md](CHANGELOG.md) v0.5.12 / v0.6.2 for the full record.
 
 Full diagnostic history and architectural reasoning: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
@@ -391,8 +391,8 @@ make
 # Syntax-check the Python controller + validate the agent jar manifest
 make test
 
-# Create a release tarball (dist/ibg-controller-0.6.1.tar.gz)
-make release VERSION=0.6.1
+# Create a release tarball (dist/ibg-controller-0.6.2.tar.gz)
+make release VERSION=0.6.2
 
 # Install directly into a running ibgateway home (for dev on host, or
 # as called by the Docker image's setup stage)
@@ -404,7 +404,7 @@ Build requires a JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.
 ### Installing from a release tarball (for consumers who don't build)
 
 ```bash
-VER=0.6.1
+VER=0.6.2
 curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${VER}/ibg-controller-${VER}.tar.gz
 tar -xzf ibg-controller-${VER}.tar.gz
 cd ibg-controller-${VER}
@@ -413,7 +413,7 @@ DESTDIR=/home/ibgateway ./install.sh
 
 The tarball layout is flat:
 ```
-ibg-controller-0.6.1/
+ibg-controller-0.6.2/
 ├── gateway-input-agent.jar   ← installed to $DESTDIR/gateway-input-agent.jar
 ├── gateway_controller.py      ← installed to $DESTDIR/scripts/gateway_controller.py
 ├── ibc_config_to_env.py       ← one-shot IBC config.ini → env migration tool
@@ -542,7 +542,7 @@ start. Check:
 > **Pre-v0.5.12 deployments only:** if you're still on a release that
 > used the AT-SPI desktop tree for app discovery and you see "IBKR
 > Gateway never appeared in AT-SPI desktop tree within 120s",
-> upgrade. v0.5.12+ doesn't use AT-SPI at all and v0.6.1 removed the
+> upgrade. v0.5.12+ doesn't use AT-SPI at all and v0.6.2 removed the
 > ATK install steps from the image; both error modes are gone.
 
 ### "Existing session detected" dialog keeps appearing in a loop

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,6 +76,47 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
+### v0.6.2
+
+**No breaking changes.** Real fix for the dual-mode post-login config
+bug that v0.6.1's diagnostic logging surfaced.
+
+Symptom (pre-v0.6.2 in dual mode): paper applied `READ_ONLY_API` /
+`TWS_MASTER_CLIENT_ID` / etc. correctly; live silently failed at the
+"open Configure → Settings dialog" step with `agent CLICK 'Settings':
+ERR not_found type=button name=Settings` in the v0.6.1 logs.
+
+Root cause: live mode emerges from 2FA + Authenticating overlays
+into the CONFIG state with the EDT still processing window
+tear-down. `_config_open()`'s 0.3 s sleep between the Configure
+click and the Settings click was enough on a quiescent EDT (paper,
+which skips 2FA) but not on a busy one (live), so the Settings
+JMenuItem wasn't yet findable in `Window.getWindows()` when the
+agent looked for it.
+
+Fix: wait for the window stack to settle (no modal dialogs, no
+Authenticating overlay), raise the inter-click delay to 1.0 s,
+and add an outer 3-attempt retry as a backstop. Cost on the success
+path is ~1 s of additional wait per CONFIG transition.
+
+**No operator action required for the redeploy** beyond pulling the
+new image. Anyone who was hitting the bug should see the live-mode
+post-login config knobs (`READ_ONLY_API`, `TWS_MASTER_CLIENT_ID`,
+`AUTO_LOGOFF_TIME`, `AUTO_RESTART_TIME`) actually apply this
+release.
+
+What you'll notice in the logs:
+
+```
+HH:MM:SS [INFO] [live] Post-login config env: ... READ_ONLY_API='no' (coerced=False) ...
+HH:MM:SS [INFO] [live] Applying post-login configuration from env vars
+HH:MM:SS [INFO] [live]   Navigating to API → Settings
+HH:MM:SS [INFO] [live]   Setting Read-Only API = False
+```
+
+— with `[live]` prefixes that v0.6.1 introduced and the apply path
+that v0.6.2 unblocks.
+
 ### v0.6.1
 
 **No breaking changes.** Operational improvement for dual-mode

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -49,7 +49,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from zoneinfo import ZoneInfo
 
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 # Wall-clock timestamp recorded when the controller module loads. Reported
 # by the /health endpoint as `uptime_seconds` so monitoring can spot a
@@ -1818,32 +1818,101 @@ def _config_open():
     """Open the Configure → Settings dialog. Idempotent — returns True
     whether it's newly opened or was already open. Returns False if the
     dialog couldn't be opened (e.g. main window not in a state to
-    accept menu input)."""
+    accept menu input).
+
+    v0.6.2: hardened against a dual-mode-only race that surfaced after
+    v0.6.1's diagnostic logging revealed it. Live mode transitions
+    API_WAIT → CONFIG within ~3 s of the API port opening, with the
+    EDT still processing post-2FA tear-down (modal=true 2FA dialog
+    being disposed, "Authenticating..." overlay being torn down).
+    Paper mode, which skips 2FA, hits the same code path with a
+    quiescent EDT.
+
+    Symptoms (pre-v0.6.2): agent CLICK 'Configure' returns OK (the
+    JMenu's selected property flips), but the JPopupMenu's heavyweight
+    peer window hasn't been realized by the time the follow-up
+    CLICK 'Settings' walks Window.getWindows(). The agent reports
+    ``ERR not_found type=button name=Settings`` and post-login config
+    silently fails on live but works on paper.
+
+    Three changes:
+
+    1. Wait for the post-login window stack to settle before clicking
+       Configure — no modal dialogs visible, no "Authenticating..."
+       window present. Bounded so we eventually proceed even on
+       Gateway showing a transitional window we haven't explicitly
+       named.
+    2. Inter-click delay between Configure and Settings raised from
+       0.3 s to 1.0 s. That's the time the EDT needs to realize the
+       JPopupMenu's heavyweight peer window when it's coming out of
+       a busy state. Empirically 0.3 s was enough on a quiescent EDT
+       (paper) and not enough on a busy one (live post-2FA).
+    3. Outer retry: up to 3 attempts to open the dialog, with a 1 s
+       gap between attempts. Backstop for any other transient.
+    """
     # Check if it's already open
     windows = agent_windows() or []
     if any(CONFIG_WINDOW_TITLE_SUBSTR in title for _, title, _ in windows):
         return True
 
-    # Click the Configure menu first. In the post-login main window
-    # this is a JMenu in a JMenuBar. Clicking it via doClick() in the
-    # agent exposes its child JMenuItems as findable AbstractButtons
-    # even though the popup isn't shown on screen.
-    if not agent_click("Configure"):
-        log.warning("Could not click Configure menu")
-        return False
-    time.sleep(0.3)
-    # Now click Settings inside the (conceptually open) Configure menu.
-    # This opens the Trader Workstation Configuration dialog.
-    if not agent_click("Settings"):
-        log.warning("Could not click Settings menu item")
-        return False
-    # Give Gateway a moment to render the dialog.
-    for _ in range(20):  # up to 4s
+    # Wait for the post-login window stack to settle. Targets the live
+    # post-2FA transitional state that lingers a second or two past
+    # API-port-open. Returns immediately if already settled.
+    settle_deadline = time.monotonic() + 5.0
+    while time.monotonic() < settle_deadline:
         windows = agent_windows() or []
-        if any(CONFIG_WINDOW_TITLE_SUBSTR in title for _, title, _ in windows):
-            return True
-        time.sleep(0.2)
-    log.warning("Settings dialog did not appear after clicking Configure → Settings")
+        modal_present = any(modal for _, _, modal in windows)
+        authenticating_present = any(
+            "Authenticating" in title for _, title, _ in windows)
+        if not modal_present and not authenticating_present:
+            break
+        time.sleep(0.3)
+    else:
+        log.info(
+            "_config_open: window stack did not fully settle within 5 s; "
+            "attempting Configure → Settings anyway")
+
+    last_failure = "no attempt made"
+    for attempt in range(1, 4):
+        # Click the Configure menu. In the post-login main window this
+        # is a JMenu in a JMenuBar. Clicking it via doClick() in the
+        # agent flips the JMenu's selected property and the EDT
+        # subsequently realizes a JPopupMenu (heavyweight window on
+        # Linux Swing) holding the child JMenuItems.
+        if not agent_click("Configure"):
+            last_failure = "Configure click failed"
+            log.info(
+                f"_config_open: {last_failure} "
+                f"(attempt {attempt}/3) — retrying after 1 s")
+            time.sleep(1.0)
+            continue
+        # Let the JPopupMenu's heavyweight peer window be realized
+        # before we walk Window.getWindows() looking for "Settings".
+        # 1.0 s is empirically enough even on a busy EDT post-2FA.
+        time.sleep(1.0)
+        if not agent_click("Settings"):
+            last_failure = "Settings JMenuItem not findable"
+            log.info(
+                f"_config_open: {last_failure} "
+                f"(attempt {attempt}/3) — retrying after 1 s")
+            time.sleep(1.0)
+            continue
+        # Wait for the Configuration dialog itself to render.
+        for _ in range(20):  # up to 4 s
+            windows = agent_windows() or []
+            if any(CONFIG_WINDOW_TITLE_SUBSTR in title
+                   for _, title, _ in windows):
+                return True
+            time.sleep(0.2)
+        last_failure = "dialog did not render after Settings click"
+        log.info(
+            f"_config_open: {last_failure} "
+            f"(attempt {attempt}/3) — retrying after 1 s")
+        time.sleep(1.0)
+
+    log.warning(
+        f"_config_open: failed to open Configure → Settings after "
+        f"3 attempts; last failure: {last_failure}")
     return False
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # running ibgateway container's filesystem.
 #
 # Usage (from the docker image's setup stage):
-#   ARG IBG_CONTROLLER_VERSION=0.6.1
+#   ARG IBG_CONTROLLER_VERSION=0.6.2
 #   RUN curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${IBG_CONTROLLER_VERSION}/ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       tar -xzf ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       cd ibg-controller-${IBG_CONTROLLER_VERSION} && \


### PR DESCRIPTION
## Summary

Real fix for the dual-mode post-login-config bug that v0.6.1's diagnostic logging surfaced. v0.6.1 ruled out scenarios (a) — env-transmission failure — and (b) — log misattribution — and revealed scenario (c): an EDT-timing race in `_config_open()` specific to live mode.

## What v0.6.1 told us

The futures-admin's reproduction with v0.6.1 produced:

- Both `[live]` and `[paper]` `Post-login config env:` lines showed identical `READ_ONLY_API='no' (coerced=False)` values → scenario (a) ruled out.
- Both modes entered the apply path with `Applying post-login configuration from env vars` → scenario (b) ruled out.
- Live then failed with `agent CLICK 'Settings': ERR not_found type=button name=Settings` while paper succeeded.

So the failure is in `_config_open()`, asymmetric between live and paper, and live-specific.

## Root cause

Live transitions `API_WAIT → CONFIG` within ~3s of the API port opening, with the EDT still processing post-2FA tear-down (modal=true 2FA dialog being disposed, "Authenticating..." overlay being torn down). `_config_open()` does:

```python
agent_click("Configure")     # JMenu.doClick(): sets selected=true
time.sleep(0.3)              # gamble that JPopupMenu is realized
agent_click("Settings")      # walks Window.getWindows()
```

For paper (which skips 2FA, then flows through DISCLAIMERS), the EDT is quiescent and 0.3s is plenty for the `JPopupMenu`'s heavyweight peer to materialize in the JVM's Window list. For live, the EDT is busy with tear-down work and 0.3s isn't enough — the `JPopupMenu` hasn't been realized, the "Settings" `JMenuItem` isn't in `Window.getWindows()`, and the agent rightly reports `ERR not_found`.

## Fix (three changes in `_config_open()`)

1. **Wait for the post-login window stack to settle** before clicking Configure: no modal dialogs visible, no `Authenticating...` window present. Bounded at 5s; logs and proceeds anyway if Gateway is showing a different transitional window we haven't explicitly named. Targets the live post-2FA transitional state directly.

2. **Inter-click delay between Configure and Settings raised from 0.3s to 1.0s.** Empirically 0.3s was enough on a quiescent EDT (paper) and not enough on a busy one (live post-2FA).

3. **Outer retry loop** — up to 3 attempts, 1s gap between attempts. Backstop for any other transient. Each attempt is the full Configure → 1s sleep → Settings → wait-for-dialog sequence.

Net cost on success path: ~1s extra per CONFIG transition. For the failing case: post-login config now applies on live in dual-mode runs.

## Why this fix and not a simpler one

The futures-admin's suggestion (retry loop on first failure) addresses the symptom but not the cause. A retry alone would oscillate the JMenu's selected state on each iteration (`doClick()` toggles selection), so we'd be reopening/reclosing the popup menu. The window-settle wait directly addresses the race, the larger inter-click delay fixes the JPopupMenu realization timing, and the retry provides defense-in-depth.

## Validation

- [x] 224 unit tests pass (no test changes — the fix is at the agent-socket boundary, exercised by integration spikes not unit tests)
- [x] `python3 -m py_compile gateway_controller.py` — OK
- [x] `bash -n docker/run.sh` — OK
- [ ] CI green
- [ ] Spike: same dual-mode setup as v0.6.1 (`TWS_USERID + TWS_USERID_PAPER + READ_ONLY_API=no`). Expected new line: `[live] [INFO]   Setting Read-Only API = False` — which was missing in the v0.6.1 logs.

Refs the v0.6.1 bug report logs the futures-admin captured.