### PR TITLE
v0.6.3 — restore honest TWOFA_DEVICE 'not honored' warning (refs #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [0.6.3] - 2026-05-11
+
+### Fixed
+
+- **Restored the `TWOFA_DEVICE` "not honored" startup warning.** A
+  prior release removed `TWOFA_DEVICE` from `_warn_unsupported_env_vars()`
+  with a comment claiming "the controller handles IB Key push 2FA" —
+  conflating two different things. IB Key *push* on a **single-method**
+  account is handled (the controller polls for the dialog to dismiss
+  after the user approves on their phone). But `TWOFA_DEVICE` as a
+  **device selector** among *multiple* enabled methods was never
+  implemented, so setting it was a silent no-op. Users with both
+  IB Key and Mobile Authenticator enabled (IB Key listed first) set
+  `TWOFA_DEVICE=Mobile Authenticator app`, got no warning, and hit a
+  login failure where the TOTP code is entered into the wrong control
+  (reported in issue #7). The controller now warns clearly at startup
+  that `TWOFA_DEVICE` is set but not yet honored, names the exact
+  failure mode, and links the tracking issue.
+
+  This is the diagnostic half. The actual device-selection feature
+  (driving Gateway's multi-method chooser) is in progress — see
+  issue #7. Single-method TOTP accounts and single-method IB Key push
+  are unaffected by this release either way.
+
+### Validation
+
+- 225 unit tests pass (the `test_twofa_device_no_longer_warned`
+  assertion was flipped to `test_twofa_device_warned_when_set`, and a
+  `test_twofa_device_not_warned_when_unset` companion added to confirm
+  the warning is gated on the var being set).
+- `python3 -m py_compile gateway_controller.py`: OK.
+
 ## [0.6.2] - 2026-05-01
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make
 make install DESTDIR=/home/ibgateway
 
 # Create a release tarball
-make release VERSION=0.6.2
+make release VERSION=0.6.3
 ```
 
 Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Version is overridable on the command line:
 #   make release VERSION=0.2.0
 
-VERSION          ?= 0.6.2
+VERSION          ?= 0.6.3
 NAME             := ibg-controller
 DIST             := dist
 AGENT_SRC        := agent/GatewayInputAgent.java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d --name ibkr \
 ```
 
 Tags published: `:latest`, `:<major>.<minor>` (e.g. `:0.5`), and
-`:v<major>.<minor>.<patch>` (e.g. `:v0.6.2`). Every tag is signed with
+`:v<major>.<minor>.<patch>` (e.g. `:v0.6.3`). Every tag is signed with
 cosign via Sigstore keyless signing — see [`SECURITY.md`](SECURITY.md)
 for the verification recipe. For reproducible deployments, pin to a
 digest (`ghcr.io/code-hustler-ft3d/ibg-controller@sha256:...`) — the
@@ -127,7 +127,7 @@ Quick start above instead.
 | **Python 3.10+** | For f-strings with `=` and type hints. |
 | **JDK 17+** | Only at *build* time, for the agent. Runtime uses Gateway's bundled Zulu JRE. |
 | **Ubuntu packages** | `python3 matchbox-window-manager` (matchbox provides focus routing for Xvfb; Xvfb itself ships in the upstream `gnzsnz/ib-gateway` image) |
-| **JRE config** | None. Pre-v0.6.2 the image wrote `accessibility.properties` and copied `libatk-wrapper.so` into the JRE; both were dropped after v0.5.12 disabled the AT-SPI bridge in the JVM. |
+| **JRE config** | None. Pre-v0.6.3 the image wrote `accessibility.properties` and copied `libatk-wrapper.so` into the JRE; both were dropped after v0.5.12 disabled the AT-SPI bridge in the JVM. |
 
 ## Compatibility table
 
@@ -205,9 +205,9 @@ corresponding product.
   clicks. v0.5.12 disabled the bridge in the JVM after a thread-dump
   showed `AtkWrapper$5.propertyChange` deadlocking on
   `JProgressBar.setValue` calls during login (surfaced as a misleading
-  `CCP LOCKOUT DETECTED` warning); v0.6.2 removed the install-time
+  `CCP LOCKOUT DETECTED` warning); v0.6.3 removed the install-time
   ATK packages and JRE configuration entirely. See
-  [CHANGELOG.md](CHANGELOG.md) v0.5.12 / v0.6.2 for the full record.
+  [CHANGELOG.md](CHANGELOG.md) v0.5.12 / v0.6.3 for the full record.
 
 Full diagnostic history and architectural reasoning: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
@@ -391,8 +391,8 @@ make
 # Syntax-check the Python controller + validate the agent jar manifest
 make test
 
-# Create a release tarball (dist/ibg-controller-0.6.2.tar.gz)
-make release VERSION=0.6.2
+# Create a release tarball (dist/ibg-controller-0.6.3.tar.gz)
+make release VERSION=0.6.3
 
 # Install directly into a running ibgateway home (for dev on host, or
 # as called by the Docker image's setup stage)
@@ -404,7 +404,7 @@ Build requires a JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.
 ### Installing from a release tarball (for consumers who don't build)
 
 ```bash
-VER=0.6.2
+VER=0.6.3
 curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${VER}/ibg-controller-${VER}.tar.gz
 tar -xzf ibg-controller-${VER}.tar.gz
 cd ibg-controller-${VER}
@@ -413,7 +413,7 @@ DESTDIR=/home/ibgateway ./install.sh
 
 The tarball layout is flat:
 ```
-ibg-controller-0.6.2/
+ibg-controller-0.6.3/
 ├── gateway-input-agent.jar   ← installed to $DESTDIR/gateway-input-agent.jar
 ├── gateway_controller.py      ← installed to $DESTDIR/scripts/gateway_controller.py
 ├── ibc_config_to_env.py       ← one-shot IBC config.ini → env migration tool
@@ -542,7 +542,7 @@ start. Check:
 > **Pre-v0.5.12 deployments only:** if you're still on a release that
 > used the AT-SPI desktop tree for app discovery and you see "IBKR
 > Gateway never appeared in AT-SPI desktop tree within 120s",
-> upgrade. v0.5.12+ doesn't use AT-SPI at all and v0.6.2 removed the
+> upgrade. v0.5.12+ doesn't use AT-SPI at all and v0.6.3 removed the
 > ATK install steps from the image; both error modes are gone.
 
 ### "Existing session detected" dialog keeps appearing in a loop

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,6 +76,33 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
+### v0.6.3
+
+**No breaking changes.** Restores an honest startup warning for
+`TWOFA_DEVICE`.
+
+If your IBKR account has a single second-factor method (just Mobile
+Authenticator / TOTP, or just IB Key push), nothing changes — your
+setup is unaffected and you'll see no new warning unless you have
+`TWOFA_DEVICE` set.
+
+If you have **multiple** 2FA methods enabled (e.g. IB Key *and*
+Mobile Authenticator) and you set `TWOFA_DEVICE` expecting the
+controller to pick one, you'll now see a startup warning that it is
+**not yet honored**. That's the truth — the controller can't yet
+drive Gateway's device chooser, so on a multi-method account
+automated TOTP login can fail (the code lands in the wrong control).
+A prior release silently dropped this warning; v0.6.3 brings it back
+so you're not left debugging a phantom bug. The real device-selection
+feature is tracked in
+[issue #7](https://github.com/code-hustler-ft3d/ibg-controller/issues/7).
+
+**No operator action required** beyond the redeploy. If you're hit by
+the multi-method limitation, the interim options are: (a) disable the
+non-TOTP method on the IBKR account so only Mobile Authenticator
+remains, or (b) stay on a manual/VNC login for that account until the
+fix ships.
+
 ### v0.6.2
 
 **No breaking changes.** Real fix for the dual-mode post-login config

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -49,7 +49,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from zoneinfo import ZoneInfo
 
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 # Wall-clock timestamp recorded when the controller module loads. Reported
 # by the /health endpoint as `uptime_seconds` so monitoring can spot a
@@ -3231,10 +3231,6 @@ def _warn_unsupported_env_vars():
     #   BYPASS_WARNING  → _resolve_safe_dismiss_buttons() extends the
     #                     disclaimer allowlist at module load
     #   TWS_COLD_RESTART → apply_warm_state() skips when set
-    # TWOFA_DEVICE is no longer in this list: the controller handles
-    # IB Key push 2FA by polling for the dialog to disappear (the user
-    # approves on their phone, the dialog goes away, we proceed). Same
-    # approach as ibctl. Not as hands-free as TOTP but not impossible.
     unsupported = {
         "CUSTOM_CONFIG":
             "not honored; the controller reads env vars directly and "
@@ -3251,6 +3247,36 @@ def _warn_unsupported_env_vars():
                     "for those specific behaviors:")
         for name, reason in hit:
             log.warning(f"  - {name}: {reason}")
+
+    # TWOFA_DEVICE gets a dedicated, more specific warning. It is NOT a
+    # flat "stay on IBC" — it's "set but not yet honored, here's the
+    # exact failure mode." IBC used TWOFA_DEVICE to pick among multiple
+    # enabled second-factor methods (e.g. "IB Key" vs "Mobile
+    # Authenticator app") on accounts that have more than one. The
+    # controller does not yet drive that device chooser: handle_2fa()
+    # assumes the Second Factor Authentication dialog presents a single
+    # code field and types the TOTP into it. On a multi-method account
+    # where Gateway lists the devices (IB Key typically first), the TOTP
+    # lands in the wrong control and login fails — the controller can't
+    # reach the Mobile Authenticator code field. Single-method TOTP
+    # accounts, and IB Key push on a single-method account (handled by
+    # polling for dialog dismissal after the user approves on their
+    # phone), are both unaffected.
+    #
+    # Removing this warning in a prior release created a silent no-op
+    # trap: users set TWOFA_DEVICE, saw nothing, and assumed it worked.
+    # Device-selection support is tracked + in progress in issue #7;
+    # this warning stays until that ships.
+    if os.environ.get("TWOFA_DEVICE"):
+        log.warning(
+            "TWOFA_DEVICE is set but NOT yet honored. The controller "
+            "cannot currently select among multiple second-factor "
+            "devices. If your IBKR account has more than one 2FA method "
+            "enabled (e.g. IB Key + Mobile Authenticator app) and Gateway "
+            "presents a device chooser at login, automated TOTP will "
+            "likely fail (the code is entered in the wrong control). "
+            "Single-method TOTP accounts are unaffected. Tracking: "
+            "https://github.com/code-hustler-ft3d/ibg-controller/issues/7")
 
 
 def main():

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # running ibgateway container's filesystem.
 #
 # Usage (from the docker image's setup stage):
-#   ARG IBG_CONTROLLER_VERSION=0.6.2
+#   ARG IBG_CONTROLLER_VERSION=0.6.3
 #   RUN curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${IBG_CONTROLLER_VERSION}/ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       tar -xzf ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       cd ibg-controller-${IBG_CONTROLLER_VERSION} && \

--- a/tests/test_env_compat.py
+++ b/tests/test_env_compat.py
@@ -156,12 +156,15 @@ class TestUnsupportedEnvVarsList(unittest.TestCase):
         joined = "\n".join(captured)
         self.assertIn("CUSTOM_CONFIG", joined)
 
-    def test_twofa_device_no_longer_warned(self):
-        # TWOFA_DEVICE was moved OUT of the warning list because the
-        # controller now handles IB Key push 2FA (poll for dialog
-        # dismissal). It should NOT appear in the warning output.
+    def test_twofa_device_warned_when_set(self):
+        # TWOFA_DEVICE is set but not yet honored (the controller can't
+        # select among multiple second-factor devices — see issue #7).
+        # A prior release removed this warning, creating a silent no-op
+        # trap; it must fire so users with multi-method accounts aren't
+        # left debugging a phantom bug. It should also point at the
+        # tracking issue.
         prev = os.environ.get("TWOFA_DEVICE")
-        os.environ["TWOFA_DEVICE"] = "mobile"
+        os.environ["TWOFA_DEVICE"] = "Mobile Authenticator app"
         captured = []
         real_warn = gc.log.warning
         gc.log.warning = lambda m, *a, **k: captured.append(m if not a else m % a)
@@ -172,6 +175,24 @@ class TestUnsupportedEnvVarsList(unittest.TestCase):
             if prev is None:
                 os.environ.pop("TWOFA_DEVICE", None)
             else:
+                os.environ["TWOFA_DEVICE"] = prev
+        joined = "\n".join(captured)
+        self.assertIn("TWOFA_DEVICE", joined)
+        self.assertIn("issues/7", joined)
+
+    def test_twofa_device_not_warned_when_unset(self):
+        # The warning is gated on the var being set — an unset
+        # TWOFA_DEVICE must NOT produce a spurious warning.
+        prev = os.environ.get("TWOFA_DEVICE")
+        os.environ.pop("TWOFA_DEVICE", None)
+        captured = []
+        real_warn = gc.log.warning
+        gc.log.warning = lambda m, *a, **k: captured.append(m if not a else m % a)
+        try:
+            gc._warn_unsupported_env_vars()
+        finally:
+            gc.log.warning = real_warn
+            if prev is not None:
                 os.environ["TWOFA_DEVICE"] = prev
         joined = "\n".join(captured)
         self.assertNotIn("TWOFA_DEVICE", joined)


### PR DESCRIPTION
## Summary

Diagnostic half of issue #7. Restores the startup warning that `TWOFA_DEVICE` is set-but-not-honored, closing a silent no-op trap.

## What I verified (from our own source, not the reporter's artifacts)

`handle_2fa()` matches the `"Second Factor"` window and, in TOTP mode, types the code into the **first text field** of that window then clicks OK — with **no device-selection logic at all**. On a single-method account that's correct. On a multi-method account (IB Key + Mobile Authenticator, IB Key listed first), Gateway presents a device chooser, so the TOTP lands in the wrong control. That matches the reporter's "code entered in a weird place" symptom exactly, and it's confirmed by reading our code alone.

Separately: `TWOFA_DEVICE` is read by **nothing** in the codebase (grep-confirmed), yet a prior release *removed* it from the `_warn_unsupported_env_vars()` list with a comment claiming "the controller handles IB Key push 2FA." That conflated two different things:

- **IB Key push on a single-method account** — genuinely handled (poll for dialog dismissal after the user approves on their phone). ✅
- **`TWOFA_DEVICE` as a device selector among multiple methods** — never implemented. ❌

So a user sets `TWOFA_DEVICE=Mobile Authenticator app`, gets no warning, and assumes it works. The function's own docstring says its job is to "tell them at startup so they don't debug a phantom bug later" — the removal created exactly that phantom bug.

## What this PR does

- Adds a dedicated `TWOFA_DEVICE` warning in `_warn_unsupported_env_vars()`, gated on the var being set, naming the exact failure mode and linking issue #7.
- Rewrites the misleading comment.
- Flips `test_twofa_device_no_longer_warned` → `test_twofa_device_warned_when_set` (asserts the warning + the `issues/7` link fire) and adds `test_twofa_device_not_warned_when_unset` to confirm the warning is gated on the var being set.

## What this PR is NOT

The actual device-selection feature. That's a separate WIP branch — it needs a new Java-agent `JLIST_SELECT` command (IBC drives Gateway's multi-method chooser via a `JList`: `setSelectedIndex` on the matching entry, then click OK), Python wiring in `handle_2fa()`, and a real-account spike to validate. It's gated on a component-tree dump from a dual-method account to confirm the dialog is a `JList` (vs. combobox/radio) and whether code entry is same-dialog or a follow-on. Shipping this warning now protects every multi-method user from the silent trap in the meantime.

## Test plan

- [x] 225 unit tests pass (was 224; flipped one, added one)
- [x] `python3 -m py_compile gateway_controller.py` — OK
- [ ] CI green

Refs #7.