### PR TITLE
v0.6.3 — SECURITY: never emit JPasswordField contents in agent dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [0.6.3] - 2026-05-11
+
+### Security
+
+- **Plaintext password could be written to logs via a window dump.**
+  The in-JVM agent's `WINDOW` dump (`dumpComponentTree`) called
+  `getText()` on every `JTextComponent`. `JPasswordField` is a
+  `JTextComponent`, and its `getText()` returns the **plaintext
+  password** — which the controller had typed into the login frame.
+  The login-failure diagnostic in `gateway_controller.py` logs that
+  dump of the `"IBKR Gateway"` window at **ERROR level** (always
+  emitted, not gated on `CONTROLLER_DEBUG`), so on a login-button
+  click failure the IBKR password could land in `docker logs` — the
+  very output the bug-report template asks users to attach.
+
+  - **Scope / reachability:** not an every-run leak. It required the
+    `Log In` / `Paper Log In` click to fail (both agent clicks
+    returning false), which triggers the ERROR-level dump while the
+    password field is populated. No evidence it was triggered in
+    practice; what shipped was the latent path, present in releases
+    up to and including **v0.6.2**.
+  - **Fix (root):** the agent now masks `JPasswordField` in
+    `dumpComponentTree` — it emits `<redacted password len=N>` and
+    never calls `getText()` on a password field (the transient
+    `getPassword()` char[] is zeroed after reading its length). This
+    closes the leak for *all* dump callers at once.
+  - **Fix (defense-in-depth):** the login-failure dump and the
+    `CONTROLLER_TEST_MODE` dump in `gateway_controller.py` now run
+    every line through `_redact_logs` (which strips `DU/U` account
+    numbers from window titles).
+  - **Hardening (same invariant):** the agent's `GETTEXT` command now
+    refuses a `JPasswordField` (returns `ERR refused type=password`)
+    so the agent never hands back a password over the socket via any
+    command. No controller code path calls `GETTEXT` on the password
+    field, so this is non-breaking.
+
+  **If you ran v0.6.2 or earlier:** upgrade, and treat any saved
+  controller logs from a *login failure* as potentially
+  password-bearing — rotate the password if such logs were shared or
+  shipped to an aggregator. Single successful logins did not hit this
+  path.
+
+### Validation
+
+- 224 unit tests pass (no behavioral change to tested Python paths;
+  the fix is at the agent boundary + two dump callsites).
+- `python3 -m py_compile gateway_controller.py`: OK.
+- The Java agent change is compile-checked by CI (`make` +
+  `gateway-version-matrix`); the masked-dump output is confirmed by
+  spike against a live login.
+
 ## [0.6.2] - 2026-05-01
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make
 make install DESTDIR=/home/ibgateway
 
 # Create a release tarball
-make release VERSION=0.6.2
+make release VERSION=0.6.3
 ```
 
 Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Version is overridable on the command line:
 #   make release VERSION=0.2.0
 
-VERSION          ?= 0.6.2
+VERSION          ?= 0.6.3
 NAME             := ibg-controller
 DIST             := dist
 AGENT_SRC        := agent/GatewayInputAgent.java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d --name ibkr \
 ```
 
 Tags published: `:latest`, `:<major>.<minor>` (e.g. `:0.5`), and
-`:v<major>.<minor>.<patch>` (e.g. `:v0.6.2`). Every tag is signed with
+`:v<major>.<minor>.<patch>` (e.g. `:v0.6.3`). Every tag is signed with
 cosign via Sigstore keyless signing — see [`SECURITY.md`](SECURITY.md)
 for the verification recipe. For reproducible deployments, pin to a
 digest (`ghcr.io/code-hustler-ft3d/ibg-controller@sha256:...`) — the
@@ -611,10 +611,16 @@ trading tool. But there are real things to get right.
 
 **Logs and sharing them**:
 
-1. `CONTROLLER_DEBUG=1` dumps modal dialog contents. The controller
-   redacts account numbers matching `DU\d{5,10}` / `U\d{5,10}` (IBKR
-   account format) before logging. Other identifying information
-   like your username may still appear in window titles. **Review
+1. Window/dialog dumps (`CONTROLLER_DEBUG=1`, the `CONTROLLER_TEST_MODE`
+   dump, and the login-failure diagnostic) redact account numbers
+   matching `DU\d{5,10}` / `U\d{5,10}` (IBKR account format), and as of
+   **v0.6.3** the in-JVM agent masks password-field contents at the
+   source — a `JPasswordField` is emitted as `<redacted password
+   len=N>`, never its value. (Before v0.6.3 the login-failure dump
+   could log your IBKR password in plaintext; see CHANGELOG.md v0.6.3.
+   Upgrade, and if you ran an older version, treat any saved
+   login-failure logs as sensitive.) Other identifying information
+   like your username can still appear in window titles. **Review
    logs before posting them publicly**.
 2. Gateway's own `/home/ibgateway/Jts/launcher.log` is NOT
    controlled by us and may include fragments of your session. If

--- a/agent/GatewayInputAgent.java
+++ b/agent/GatewayInputAgent.java
@@ -189,10 +189,13 @@ public class GatewayInputAgent {
                 // Diagnostic: dump full component tree of windows whose
                 // title contains <substring>. Pass empty for all windows.
                 // Captures text from JLabel, JTextComponent (JTextField,
-                // JTextArea, JEditorPane, JTextPane, JPasswordField),
-                // AbstractButton (JButton, JToggleButton, JRadioButton),
-                // plus showing/visible state and accessible name. This is
-                // the way to see dialog body text that LABELS misses.
+                // JTextArea, JEditorPane, JTextPane), and AbstractButton
+                // (JButton, JToggleButton, JRadioButton), plus
+                // showing/visible state and accessible name. This is the
+                // way to see dialog body text that LABELS misses.
+                // SECURITY: JPasswordField contents are NEVER emitted —
+                // only a "<redacted password len=N>" placeholder (see
+                // dumpComponentTree).
                 return doDumpWindow(rest);
             }
             case "SETTEXT_IN_WIN": {
@@ -337,6 +340,15 @@ public class GatewayInputAgent {
         JTextComponent field = findByName(JTextComponent.class, name);
         if (field == null) {
             return "ERR not_found type=text name=" + name;
+        }
+        // SECURITY: never return a password field's contents over the
+        // socket. GETTEXT is only used to read back non-password fields
+        // for verification; no controller code path calls it on the
+        // login JPasswordField (SETTEXT_LOGIN_PASSWORD has no readback).
+        // Refuse defensively so the agent never hands a plaintext
+        // password to any caller via any command.
+        if (field instanceof javax.swing.JPasswordField) {
+            return "ERR refused type=password name=" + name;
         }
         final String[] result = new String[1];
         SwingUtilities.invokeAndWait(() -> result[0] = field.getText());
@@ -818,6 +830,20 @@ public class GatewayInputAgent {
             text = ((AbstractButton) c).getText();
         } else if (c instanceof JLabel) {
             text = ((JLabel) c).getText();
+        } else if (c instanceof javax.swing.JPasswordField) {
+            // SECURITY: never emit a password field's contents. A
+            // JPasswordField is a JTextComponent, so the generic branch
+            // below would call getText() and return the PLAINTEXT
+            // password — which then lands in any log that prints this
+            // dump (e.g. the login-failure diagnostic in the Python
+            // controller). Emit only the length so the field is still
+            // visible in the tree for debugging, never the value. This
+            // branch MUST come before the JTextComponent branch since
+            // JPasswordField extends JTextField extends JTextComponent.
+            char[] pw = ((javax.swing.JPasswordField) c).getPassword();
+            int len = pw.length;
+            java.util.Arrays.fill(pw, '\0');  // don't leave a plaintext copy
+            text = "<redacted password len=" + len + ">";
         } else if (c instanceof JTextComponent) {
             text = ((JTextComponent) c).getText();
         }

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,6 +76,35 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
+### v0.6.3
+
+**Security fix — upgrade recommended.** A plaintext IBKR password
+could be written to the controller's logs.
+
+The in-JVM agent's window dump emitted `JPasswordField` contents
+(`getText()` returns the plaintext password), and the controller's
+login-failure diagnostic logs that dump at ERROR level. So if the
+`Log In` button click failed, your password could appear in
+`docker logs` — the output the bug-report template asks for.
+
+It was **not** an every-run leak: it required a login-button-click
+failure with the password field populated. But the latent path
+shipped through v0.6.2.
+
+v0.6.3 masks `JPasswordField` at the agent (`<redacted password
+len=N>`, never the value), routes the login-failure and TEST_MODE
+dumps through `_redact_logs` for account numbers, and makes the
+agent's `GETTEXT` refuse password fields.
+
+**Action:**
+- Pull v0.6.3 and redeploy (rebuild the image so the new agent jar
+  is picked up — this fix is in the Java agent, not just the Python).
+- If you ran v0.6.2 or earlier and **shared or aggregated controller
+  logs from a login failure**, treat those logs as
+  password-bearing and rotate the IBKR password. Logs from
+  successful logins are unaffected (the dump only fires on the
+  failure path).
+
 ### v0.6.2
 
 **No breaking changes.** Real fix for the dual-mode post-login config

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -49,7 +49,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from zoneinfo import ZoneInfo
 
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 # Wall-clock timestamp recorded when the controller module loads. Reported
 # by the /health endpoint as `uptime_seconds` so monitoring can spot a
@@ -1164,11 +1164,18 @@ def handle_login(app):
     if not (agent_click("Log In") or agent_click("Paper Log In")):
         log.error("Log In / Paper Log In button click failed via agent")
         # Diagnostic: dump the login window's component tree via the agent.
+        # This is an ERROR-level (always-emitted) dump of the login frame,
+        # which holds the just-typed password. v0.6.3: the agent masks
+        # JPasswordField contents at the source, so the password no longer
+        # reaches this dump. We additionally run every line through
+        # _redact_logs here as defense-in-depth (it strips IBKR DU/U
+        # account numbers that can appear in window titles) and because
+        # this is exactly the dump a user copies into a bug report.
         try:
             log.error("=== agent_window('IBKR Gateway') dump ===")
             for line in agent_window("IBKR Gateway").split("\n"):
                 if line and line not in ("OK", "END"):
-                    log.error(f"  {line}")
+                    log.error(f"  {_redact_logs(line)}")
             log.error("=== end window dump ===")
         except Exception as e:
             log.error(f"  agent_window dump failed: {type(e).__name__}: {e}")
@@ -3335,10 +3342,13 @@ def main():
         log.info("CONTROLLER_TEST_MODE=1 — waiting 5s for Gateway response then dumping window state")
         time.sleep(5)
         log.info("=== POST-CLICK WINDOW DUMP (via agent) ===")
+        # v0.6.3: redact account numbers in titles; password fields are
+        # already masked at the agent. This dump is opt-in (TEST_MODE)
+        # but users still share its output, so keep it clean.
         try:
             for line in agent_window("").split("\n"):
                 if line and line not in ("OK", "END"):
-                    log.info(f"  {line}")
+                    log.info(f"  {_redact_logs(line)}")
         except Exception as e:
             log.error(f"  agent_window dump failed: {type(e).__name__}: {e}")
         sys.exit(0)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # running ibgateway container's filesystem.
 #
 # Usage (from the docker image's setup stage):
-#   ARG IBG_CONTROLLER_VERSION=0.6.2
+#   ARG IBG_CONTROLLER_VERSION=0.6.3
 #   RUN curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${IBG_CONTROLLER_VERSION}/ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       tar -xzf ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       cd ibg-controller-${IBG_CONTROLLER_VERSION} && \


### PR DESCRIPTION
## Security fix

A plaintext IBKR password could be written to the controller's logs.

### The leak
- The in-JVM agent's `WINDOW` dump (`dumpComponentTree`) did `((JTextComponent) c).getText()` on every text component. `JPasswordField` **is a** `JTextComponent`, and its `getText()` returns the **plaintext password** the controller typed into the login frame.
- `gateway_controller.py`'s login-failure diagnostic logs that dump of the `"IBKR Gateway"` window at **ERROR level** — always emitted, not gated on `CONTROLLER_DEBUG`.
- So on a `Log In` / `Paper Log In` click failure, the password could land in `docker logs` — the exact output our bug-report template asks users to attach, and which log aggregators ingest.

### Reachability (not alarmist)
Not an every-run leak. It required the login-button click to fail (both agent clicks returning false) with the password field still populated. No evidence it was triggered in practice — but the latent path shipped in releases **up to and including v0.6.2** (confirmed via `git show v0.6.2:`). There was **no** password redaction anywhere; `_redact_logs` only ever masked `DU/U` account numbers.

### Fix
1. **Root (agent):** `dumpComponentTree` masks `JPasswordField` → emits `<redacted password len=N>`, never `getText()`. The transient `getPassword()` char[] is zeroed after reading its length. Ordered before the `JTextComponent` branch (subclass). Closes the leak for **all** dump callers at once.
2. **Defense-in-depth (Python):** the login-failure dump and the `CONTROLLER_TEST_MODE` dump now route every line through `_redact_logs`.
3. **Hardening (agent):** `GETTEXT` now refuses a `JPasswordField` (`ERR refused type=password`) so the agent never returns a password over the socket via any command. No controller path calls `GETTEXT` on the password field → non-breaking.
4. Docs: corrected the WINDOW protocol-doc comment and the README "Logs and sharing them" note (it understated the risk as "username may appear").

### Coverage check
Of the four `agent_window()` call sites: login-failure (now redacted), TEST_MODE (now redacted), modal-dump (already redacted), and one used only for text-matching (never logged). Plus the password is masked at the source regardless of caller.

### Operator action (also in UPGRADING.md / CHANGELOG.md)
Pull v0.6.3 and **rebuild the image** (the core fix is in the Java agent jar, not just the Python). If you ran ≤v0.6.2 and shared/aggregated controller logs **from a login failure**, treat them as password-bearing and rotate. Successful-login logs are unaffected.

## Test plan
- [x] 224 unit tests pass; `py_compile` OK
- [ ] CI green (this is the **Java compile gate** — the agent change is only validated here, since there's no JRE in the dev env)
- [ ] Spike: trigger a login failure on a real account, confirm the dump shows `<redacted password len=N>` and not the password

## Notes
- Versioned **v0.6.3**; supersedes the parked PR #8's claim on that number (PR #8 will re-version if ever un-parked).
- Independent of issue #7 (multi-method 2FA), which remains parked pending the maintainer's component-tree dump.