### PR TITLE
v0.7.0 — multi-method 2FA device selection (TWOFA_DEVICE) [HELD FOR SPIKE]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [0.7.0] - unreleased (pending live multi-method spike)
+
+### Added
+
+- **Multi-method 2FA device selection (`TWOFA_DEVICE`), fixing issue #7.**
+  On accounts with more than one second-factor method enabled (e.g.
+  IB Key + Mobile Authenticator), Gateway presents a device **chooser**
+  (a Swing `JList`) before the code field. Pre-v0.7.0 the controller
+  ignored it and typed the TOTP into the chooser's first control (or
+  waited on the default IB Key method), so automated TOTP login failed
+  on multi-method accounts — exactly the "code entered in a weird
+  place" symptom reported in #7.
+  - **New agent command `JLIST_SELECT <title>|<value>`** — selects the
+    `JList` entry whose `toString().trim()` equals `<value>`, mirroring
+    IBC's `SecondFactorAuthenticationDialogHandler.selectSecondFactorDevice`
+    (`findList` → match model element → `setSelectedIndex`). Pure
+    selection primitive; the OK click is a separate `CLICK_IN_WIN`,
+    matching how `JCHECK` and the config dialog compose.
+  - **`handle_2fa()`** now detects the chooser and selects the wanted
+    device before entering the code / waiting for push. The device is
+    `TWOFA_DEVICE` (IBC-compatible env var, **revived** — it was a
+    silent no-op before), defaulting to `Mobile Authenticator app` in
+    TOTP mode and `IB Key` otherwise (`_resolve_twofa_device`).
+  - **Strict no-op on single-method accounts:** when no `JList` is
+    present the agent returns `ERR not_found jlist` and the controller
+    falls through to the existing code/push handling — byte-identical
+    behavior. The new path only activates when a device chooser
+    actually exists, which bounds the risk to the (already-broken)
+    multi-method case.
+  - A misconfigured `TWOFA_DEVICE` (not offered by Gateway) fails
+    cleanly with `ALERT_2FA_FAILED` and echoes the devices that *were*
+    available, instead of mis-entering the code.
+
+### Changed
+
+- `TWOFA_DEVICE` is now honored (above) rather than silently ignored;
+  the prior misleading comment in `_warn_unsupported_env_vars()`
+  claiming push 2FA "handled" it is corrected.
+
+### Validation
+
+- 229 unit tests pass, incl. new `_resolve_twofa_device` coverage
+  (explicit-wins, TOTP default, IB-Key default, whitespace handling).
+- `make` compiles the agent jar with `JLIST_SELECT` (`javac --release
+  17`); `make test` green end-to-end (manifest + py_compile + tests).
+- **NOT YET SPIKED:** the chooser interaction is verified by code +
+  IBC parity, not yet run against a live multi-method account. This
+  release is held until that spike confirms the dialog is a `JList`,
+  the device strings match, and the post-OK flow (same-dialog vs.
+  follow-on code dialog) works end-to-end. The `[0.7.0]` date is set
+  at release.
+
 ## [0.6.3] - 2026-05-11
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make
 make install DESTDIR=/home/ibgateway
 
 # Create a release tarball
-make release VERSION=0.6.3
+make release VERSION=0.7.0
 ```
 
 Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Version is overridable on the command line:
 #   make release VERSION=0.2.0
 
-VERSION          ?= 0.6.3
+VERSION          ?= 0.7.0
 NAME             := ibg-controller
 DIST             := dist
 AGENT_SRC        := agent/GatewayInputAgent.java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d --name ibkr \
 ```
 
 Tags published: `:latest`, `:<major>.<minor>` (e.g. `:0.5`), and
-`:v<major>.<minor>.<patch>` (e.g. `:v0.6.3`). Every tag is signed with
+`:v<major>.<minor>.<patch>` (e.g. `:v0.7.0`). Every tag is signed with
 cosign via Sigstore keyless signing — see [`SECURITY.md`](SECURITY.md)
 for the verification recipe. For reproducible deployments, pin to a
 digest (`ghcr.io/code-hustler-ft3d/ibg-controller@sha256:...`) — the
@@ -136,8 +136,9 @@ Quick start above instead.
 | Single-mode paper cold-start | ✅ verified | ⚠️ code in place | TWS code-path unit-tested; app-name match needs real TWS to validate |
 | Single-mode live cold-start | ✅ verified | ⚠️ code in place | |
 | Dual mode (`TRADING_MODE=both`) | ✅ verified | ⚠️ code in place | Per-instance state isolation, agent sockets, ready files, JVM-PID-scoped find_app |
-| TOTP 2FA | ✅ verified | ⚠️ code in place | |
-| IB Key push 2FA | ✅ wait mode | ✅ wait mode | Controller detects the 2FA dialog, logs "approve on your phone", polls for dialog dismissal. User approves via IB Key mobile app. Same approach as ibctl. |
+| TOTP 2FA (single method) | ✅ verified | ⚠️ code in place | |
+| IB Key push 2FA (single method) | ✅ wait mode | ✅ wait mode | Controller detects the 2FA dialog, logs "approve on your phone", polls for dialog dismissal. User approves via IB Key mobile app. Same approach as ibctl. |
+| Multi-method 2FA device selection | ⚠️ code in place | ⚠️ code in place | Account with >1 2FA method: Gateway shows a device chooser (JList). Controller selects `TWOFA_DEVICE` (default: Mobile Authenticator in TOTP mode) then enters the code. v0.7.0 (issue #7); **pending spike against a real multi-method account.** Single-method accounts unaffected. |
 | Existing-session dialog | ✅ verified | ⚠️ code in place | Clicks `Continue Login`; late-arrival handler catches the dialog if it shows during the 2FA wait |
 | `TWS_MASTER_CLIENT_ID` | ✅ verified | ⚠️ untested | Set + read back |
 | `READ_ONLY_API` | ✅ verified | ⚠️ untested | Set + read back via JCHECK |
@@ -224,6 +225,7 @@ Full diagnostic history and architectural reasoning: [`docs/ARCHITECTURE.md`](do
 | `TRADING_MODE` | `live`, `paper`, or `both` (default: `paper`). `both` runs two Gateway JVMs in parallel with isolated state. |
 | `TWOFACTOR_CODE` | Base32 TOTP secret from IBKR Mobile Authenticator setup. When set, the controller generates a TOTP code and enters it into the Second Factor Authentication dialog. |
 | `TWOFACTOR_CODE_FILE` | Alternative: read the TOTP secret from a file (Docker secrets pattern). |
+| `TWOFA_DEVICE` | IBC-compatible. Only relevant if your IBKR account has **more than one** second-factor method enabled (e.g. IB Key *and* Mobile Authenticator), in which case Gateway shows a device chooser at login. Set to the exact device label to select — e.g. `Mobile Authenticator app` or `IB Key`. Defaults to `Mobile Authenticator app` when `TWOFACTOR_CODE` is set, else `IB Key`. Ignored on single-method accounts (no chooser appears). v0.7.0+ (issue #7). |
 
 ### 2FA timeout behavior (IBC-compat)
 | Var | Notes |

--- a/agent/GatewayInputAgent.java
+++ b/agent/GatewayInputAgent.java
@@ -27,8 +27,10 @@ import javax.accessibility.AccessibleContext;
 import javax.swing.AbstractButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
+import javax.swing.JList;
 import javax.swing.JToggleButton;
 import javax.swing.JTree;
+import javax.swing.ListModel;
 import javax.swing.SwingUtilities;
 import javax.swing.text.JTextComponent;
 import javax.swing.tree.TreeModel;
@@ -55,6 +57,7 @@ import javax.swing.tree.TreePath;
  *   SETTEXT_IN_WIN <title>|<text>         → OK | ERR ...
  *   CLICK_IN_WIN <title>|<button>         → OK | ERR ...
  *   JTREE_SELECT_PATH <title>|<p1>/<p2>/..→ OK selected=<path> | ERR ...
+ *   JLIST_SELECT <title>|<value>          → OK selected=<value> index=<i> | ERR ...
  *   JCHECK <title>|<name>|<true|false>    → OK unchanged=<v> | OK changed=<v> | ERR ...
  *   SETTEXT_BY_LABEL <title>|<label>|<v>  → OK set label=<label> value=<v> | ERR ...
  *   SETTEXT_LOGIN_USER <text>             → OK | ERR ...
@@ -225,6 +228,22 @@ public class GatewayInputAgent {
                 // Configuration dialog's ConfigurationTree
                 // (e.g. "API/Settings").
                 return doJTreeSelectPath(rest);
+            }
+            case "JLIST_SELECT": {
+                // Select an entry in a JList by its displayed value.
+                // Protocol: JLIST_SELECT <title_substr>|<value>
+                // Finds the first showing JList in the first showing
+                // window whose title contains <title_substr>, then
+                // selects the entry whose model element toString().trim()
+                // equals <value>. Mirrors IBC's
+                // SecondFactorAuthenticationDialogHandler: the
+                // multi-2FA-method chooser is a JList of device names
+                // ("IB Key", "Mobile Authenticator app"); selecting the
+                // wanted device + clicking OK (via CLICK_IN_WIN) advances
+                // to the TOTP code entry. Selection only — the OK click
+                // is a separate command, matching how JCHECK and the
+                // config dialog compose primitives.
+                return doJListSelect(rest);
             }
             case "JCHECK": {
                 // Set a toggle-style button (JCheckBox, JRadioButton,
@@ -531,6 +550,65 @@ public class GatewayInputAgent {
             tree.scrollPathToVisible(targetPath);
         });
         return "OK selected=" + pathStr;
+    }
+
+    private static String doJListSelect(String rest) throws Exception {
+        int pipe = rest.indexOf('|');
+        if (pipe < 0) {
+            return "ERR jlist_select_missing_pipe";
+        }
+        String titleSubstr = rest.substring(0, pipe);
+        String value = rest.substring(pipe + 1);
+
+        Window target = findWindowByTitleSubstring(titleSubstr);
+        if (target == null) {
+            return "ERR not_found window_title_substring=" + titleSubstr;
+        }
+
+        // First showing JList in the window. The multi-method 2FA chooser
+        // is a JList of device names; mirrors IBC's
+        // SecondFactorAuthenticationDialogHandler.selectSecondFactorDevice
+        // (findList → match model element → setSelectedIndex).
+        JList<?> list = null;
+        for (JList<?> candidate : collect(target, JList.class)) {
+            if (candidate.isShowing()) {
+                list = candidate;
+                break;
+            }
+        }
+        if (list == null) {
+            return "ERR not_found jlist in_window=" + titleSubstr;
+        }
+
+        final JList<?> list2 = list;
+        final String want = value.trim();
+        final int[] matchedIndex = { -1 };
+        final StringBuilder available = new StringBuilder();
+        // Selection is a model change, not a modal-opening action, so
+        // invokeAndWait is safe (same as JCHECK / JTREE_SELECT_PATH).
+        SwingUtilities.invokeAndWait(() -> {
+            ListModel<?> model = list2.getModel();
+            for (int i = 0; i < model.getSize(); i++) {
+                Object el = model.getElementAt(i);
+                String entry = el == null ? "" : el.toString().trim();
+                if (available.length() > 0) available.append(", ");
+                available.append('"').append(entry).append('"');
+                if (matchedIndex[0] < 0 && entry.equals(want)) {
+                    matchedIndex[0] = i;
+                    list2.setSelectedIndex(i);
+                    list2.ensureIndexIsVisible(i);
+                }
+            }
+        });
+
+        if (matchedIndex[0] < 0) {
+            // Entry names are device-type labels (not credentials); echo
+            // the available list so a misconfigured TWOFA_DEVICE is
+            // diagnosable from one run.
+            return "ERR not_found jlist_entry=" + want
+                   + " available=[" + available + "]";
+        }
+        return "OK selected=" + want + " index=" + matchedIndex[0];
     }
 
     private static String doJCheck(String rest) throws Exception {

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,6 +76,33 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
+### v0.7.0
+
+**Additive — fixes multi-method 2FA login (issue #7).** If your IBKR
+account has **more than one** second-factor method enabled (e.g. both
+IB Key and Mobile Authenticator), Gateway shows a device chooser at
+login. Before v0.7.0 the controller couldn't drive it, so automated
+TOTP login failed (the code went to the wrong control). v0.7.0 selects
+the right device from the chooser, then enters the code.
+
+- **If you have a single 2FA method: nothing changes.** There's no
+  chooser, and the new code path is a strict no-op.
+- **If you have multiple methods:** set `TWOFA_DEVICE` to the device
+  you want the controller to use — e.g. `TWOFA_DEVICE=Mobile
+  Authenticator app` (the exact label Gateway shows). It defaults to
+  `Mobile Authenticator app` when `TWOFACTOR_CODE` is set, so if that's
+  your TOTP device you may not need to set it explicitly. A wrong/unknown
+  value fails cleanly with `ALERT_2FA_FAILED` and logs the devices
+  Gateway actually offered.
+- This fix is in the **Java agent jar** (new `JLIST_SELECT` command) as
+  well as the Python controller, so **rebuild/repull the image** — a
+  Python-only refresh won't pick it up.
+
+> **Maintainer note:** this version is held until it's been spiked
+> against a real multi-method account (confirming Gateway's chooser is
+> a `JList` with the expected device labels and post-selection flow).
+> The published `v0.7.0` reflects a validated build.
+
 ### v0.6.3
 
 **Security fix — upgrade recommended.** A plaintext IBKR password

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -49,7 +49,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from zoneinfo import ZoneInfo
 
 
-__version__ = "0.6.3"
+__version__ = "0.7.0"
 
 # Wall-clock timestamp recorded when the controller module loads. Reported
 # by the /health endpoint as `uptime_seconds` so monitoring can spot a
@@ -620,6 +620,27 @@ def agent_jcheck(title_substring, name, desired):
         return True
     log.error(f"agent JCHECK {name!r}: {resp}")
     return False
+
+
+def agent_jlist_select(title_substring, value):
+    """Select an entry in a JList by its displayed value. Used for the
+    multi-method 2FA device chooser (a JList of device names).
+
+    Returns the raw agent response string, or None on transport error,
+    so the caller can distinguish the three meaningful outcomes:
+      - ``OK selected=...``                  → device selected
+      - ``ERR not_found jlist ...``          → no JList in the window
+        (single-method dialog — there's no chooser to drive)
+      - ``ERR not_found jlist_entry=... available=[...]`` → the
+        requested device isn't offered (misconfigured TWOFA_DEVICE);
+        the available list is echoed for diagnosis.
+    """
+    try:
+        resp = _agent_request(f"JLIST_SELECT {title_substring}|{value}")
+    except Exception as e:
+        log.error(f"agent JLIST_SELECT {value!r}: {type(e).__name__}: {e}")
+        return None
+    return resp
 
 
 def agent_settext_by_label(title_substring, label_text, value):
@@ -1424,8 +1445,37 @@ def handle_existing_session_dialog():
     return False
 
 
+def _resolve_twofa_device(explicit, has_totp):
+    """Resolve which second-factor device to select from Gateway's
+    multi-method chooser (a JList shown only when the account has more
+    than one 2FA method enabled).
+
+    Explicit ``TWOFA_DEVICE`` wins. Otherwise default to the Mobile
+    Authenticator (TOTP) device when a TOTP secret is configured, else
+    IB Key. The result is only used if Gateway actually presents a
+    device chooser; single-method accounts never hit it.
+
+    Matches IBC's ``SecondFactorDevice`` semantics and the device
+    strings IBKR uses in the chooser ("IB Key", "Mobile Authenticator
+    app"). See issue #7.
+    """
+    explicit = (explicit or "").strip()
+    if explicit:
+        return explicit
+    return "Mobile Authenticator app" if has_totp else "IB Key"
+
+
 def handle_2fa(app):
     """Handle Gateway's Second Factor Authentication dialog.
+
+    **Multi-method device chooser (v0.7.0, issue #7):** if the account
+    has more than one second-factor method enabled, Gateway first shows
+    a JList of devices ("IB Key", "Mobile Authenticator app", ...)
+    before the code field. When that chooser is present, the controller
+    selects ``TWOFA_DEVICE`` (defaulting to the Mobile Authenticator
+    device in TOTP mode, IB Key otherwise), clicks OK, then proceeds to
+    the mode handling below. On single-method accounts there is no
+    chooser and this step is a no-op.
 
     Supports two modes:
 
@@ -1468,6 +1518,15 @@ def handle_2fa(app):
     ib_key_mode = not TOTP_SECRET
     if ib_key_mode:
         log.info("No TWOFACTOR_CODE set — will watch for IB Key push dialog if it appears")
+
+    # v0.7.0 (issue #7): which device to pick if the account has more
+    # than one second-factor method enabled and Gateway shows a device
+    # chooser (a JList). On single-method accounts there's no chooser
+    # and this is never used — the device-selection step below is a
+    # strict no-op in that case, so single-method behavior is unchanged.
+    twofa_device = _resolve_twofa_device(os.environ.get("TWOFA_DEVICE"),
+                                         bool(TOTP_SECRET))
+    device_selected = False
 
     # IBC-compat 2FA timeout configuration:
     #   TWOFA_EXIT_INTERVAL   — seconds to wait for the dialog (default 120)
@@ -1542,6 +1601,42 @@ def handle_2fa(app):
                 break
 
         if two_fa_window is not None:
+            # v0.7.0 (issue #7): multi-method device chooser. If the
+            # account has >1 second-factor method, Gateway shows a JList
+            # of devices ("IB Key", "Mobile Authenticator app", ...)
+            # BEFORE presenting the code field. Pre-v0.7.0 the controller
+            # ignored it and typed the TOTP into the chooser's first
+            # control (or waited on IB Key), so TOTP login failed on
+            # multi-method accounts. Select the wanted device + click OK,
+            # then loop back to handle the code field / push that follows.
+            #
+            # Strict no-op on single-method accounts: agent_jlist_select
+            # returns "ERR not_found jlist" (no JList present), we fall
+            # straight through to the existing code/push handling, and
+            # behavior is byte-identical to before.
+            if not device_selected:
+                sel = agent_jlist_select(TWOFA_WINDOW_SUBSTR, twofa_device)
+                if sel and sel.startswith("OK"):
+                    log.info(f"2FA device chooser: selected {twofa_device!r} "
+                             f"({sel.strip()})")
+                    if not agent_click_in_window(TWOFA_WINDOW_SUBSTR, "OK"):
+                        log.warning("2FA device chooser: OK click after device "
+                                    "select did not confirm; continuing anyway")
+                    device_selected = True
+                    last_windows = None
+                    time.sleep(1.0)
+                    continue  # re-detect: code field / push now presented
+                if sel and "not_found jlist_entry" in sel:
+                    log.error(f"2FA device chooser present but configured device "
+                              f"{twofa_device!r} is not offered: {sel.strip()}")
+                    log.error(
+                        f"ALERT_2FA_FAILED mode={TRADING_MODE} "
+                        f"reason=\"TWOFA_DEVICE not offered in chooser\" "
+                        f"device={twofa_device!r}")
+                    return False
+                # else: "ERR not_found jlist" → no chooser (single-method
+                # dialog). Fall through to the existing handling below.
+
             if ib_key_mode:
                 # IB Key push mode: the dialog appeared, IBKR sent a
                 # push notification to the user's phone. We don't type
@@ -3238,10 +3333,9 @@ def _warn_unsupported_env_vars():
     #   BYPASS_WARNING  → _resolve_safe_dismiss_buttons() extends the
     #                     disclaimer allowlist at module load
     #   TWS_COLD_RESTART → apply_warm_state() skips when set
-    # TWOFA_DEVICE is no longer in this list: the controller handles
-    # IB Key push 2FA by polling for the dialog to disappear (the user
-    # approves on their phone, the dialog goes away, we proceed). Same
-    # approach as ibctl. Not as hands-free as TOTP but not impossible.
+    #   TWOFA_DEVICE → honored as of v0.7.0 (issue #7): when the account
+    #                  has multiple 2FA methods, handle_2fa() selects the
+    #                  named device from Gateway's chooser. Not warned.
     unsupported = {
         "CUSTOM_CONFIG":
             "not honored; the controller reads env vars directly and "

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # running ibgateway container's filesystem.
 #
 # Usage (from the docker image's setup stage):
-#   ARG IBG_CONTROLLER_VERSION=0.6.3
+#   ARG IBG_CONTROLLER_VERSION=0.7.0
 #   RUN curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${IBG_CONTROLLER_VERSION}/ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       tar -xzf ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       cd ibg-controller-${IBG_CONTROLLER_VERSION} && \

--- a/tests/test_pure_logic.py
+++ b/tests/test_pure_logic.py
@@ -2033,5 +2033,38 @@ class TestRecoverJvmMaintenanceGuard(unittest.TestCase):
         mock_delay.assert_not_called()
 
 
+class TestResolveTwofaDevice(unittest.TestCase):
+    """_resolve_twofa_device picks which device to select from Gateway's
+    multi-method 2FA chooser (issue #7)."""
+
+    def test_explicit_value_wins(self):
+        self.assertEqual(
+            gc._resolve_twofa_device("IB Key", True), "IB Key")
+        self.assertEqual(
+            gc._resolve_twofa_device("Mobile Authenticator app", False),
+            "Mobile Authenticator app")
+
+    def test_explicit_is_stripped(self):
+        self.assertEqual(
+            gc._resolve_twofa_device("  Mobile Authenticator app  ", True),
+            "Mobile Authenticator app")
+
+    def test_default_totp_mode(self):
+        # No explicit device + a TOTP secret configured → Mobile Authenticator.
+        self.assertEqual(
+            gc._resolve_twofa_device("", True), "Mobile Authenticator app")
+        self.assertEqual(
+            gc._resolve_twofa_device(None, True), "Mobile Authenticator app")
+
+    def test_default_non_totp_mode(self):
+        # No explicit device + no TOTP secret → IB Key.
+        self.assertEqual(gc._resolve_twofa_device("", False), "IB Key")
+        self.assertEqual(gc._resolve_twofa_device(None, False), "IB Key")
+
+    def test_whitespace_only_falls_back_to_default(self):
+        self.assertEqual(
+            gc._resolve_twofa_device("   ", True), "Mobile Authenticator app")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
**Draft / held for spike.** Fixes issue #7. Do not merge or release until validated against a real multi-method 2FA account.

## What it fixes
On an IBKR account with more than one second-factor method (e.g. IB Key + Mobile Authenticator), Gateway shows a device **chooser** (a Swing `JList`) before the code field. The controller had no logic for it — it typed the TOTP into the chooser's first control (or waited on the default IB Key method), so automated TOTP login failed. That's the "code entered in a weird place" symptom in #7. Single-method accounts were never affected.

## Mechanism (ported from IBC, not guessed)
Direct port of IBC's `SecondFactorAuthenticationDialogHandler.selectSecondFactorDevice`: `findList(window)` → iterate the `ListModel` → match `getElementAt(i).toString().trim().equals(device)` → `setSelectedIndex(i)` → click OK. Confirmed by reading IBC source (the project's documented methodology for driving Gateway dialogs).

## Changes
- **Agent:** new `JLIST_SELECT <title>|<value>` command — selects the `JList` entry matching `<value>`. Pure selection primitive; OK click is a separate `CLICK_IN_WIN` (matches `JCHECK`/config-dialog composition). **Compiles under `javac --release 17`, validated locally** (the dev env now has JDK 17, so this isn't CI-only).
- **Controller:** `handle_2fa()` detects the chooser and selects `TWOFA_DEVICE` before code entry / push wait. `_resolve_twofa_device()` defaults to `Mobile Authenticator app` in TOTP mode, `IB Key` otherwise. `TWOFA_DEVICE` (IBC-compatible) is **revived** — it was a silent no-op before.
- **Safety — strict no-op on single-method accounts:** no `JList` → agent returns `ERR not_found jlist` → controller falls through to the existing code/push handling, **byte-identical**. The new path only activates when a chooser actually exists, bounding risk to the already-broken multi-method case.
- Misconfigured `TWOFA_DEVICE` fails cleanly (`ALERT_2FA_FAILED`) and echoes the offered devices.
- Corrected the misleading `_warn_unsupported_env_vars()` comment; `TWOFA_DEVICE` is now honored. **This supersedes the parked PR #8** (the warning) — close #8 when this merges.
- Docs: README compat row + `TWOFA_DEVICE` env entry; CHANGELOG + UPGRADING (marked unreleased/pending-spike).

## Test plan
- [x] 229 unit tests pass (+5 `_resolve_twofa_device`: explicit-wins, TOTP default, IB-Key default, whitespace)
- [x] `make test` green end-to-end (agent compile + jar manifest + py_compile + tests), locally with JDK 17
- [x] CI (will run on push)
- [ ] **SPIKE (the merge gate):** run against a real account with both IB Key + Mobile Authenticator. Confirm: (1) the chooser is a `JList`; (2) the device labels match (`IB Key` / `Mobile Authenticator app`); (3) after select+OK the code field is reachable (same dialog vs. follow-on), and TOTP completes; (4) single-method account still logs in unchanged.

## Why draft
Everything is verified that *can* be verified without a multi-method account (IBC parity, local compile, unit tests, single-method no-op reasoning). The remaining unknowns — JList-vs-other, exact labels, post-OK dialog flow — are only resolvable on a live multi-method login. Holding here until that spike.

Refs #7.