### PR TITLE
v0.7.0 — multi-method 2FA: detect method, fail clearly on mismatch (issue #7) [held for spike]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
-## [0.7.0] - unreleased (pending futures-admin validation)
+## [0.7.0] - 2026-05-30
 
 ### Fixed
 
@@ -66,9 +66,16 @@ and the project follows [Semantic Versioning](https://semver.org/).
   window substring to `agent_labels()`, which filters by label TEXT —
   the prompt text doesn't contain "Second Factor", so it was dropped.
   Fixed; the agent's recursive label walk does reach the nested prompt.
-- **Held until a confirmation spike** on the futures-admin multi-method
-  account shows the detection engaging (the "method prompt … matches …"
-  line) with login still completing. `[0.7.0]` date set at release.
+- **Live-validated (2026-05-30 spike, real multi-method account):** the
+  happy path engaged correctly —
+  `2FA method prompt 'Enter Mobile Authenticator app code' matches
+  'Mobile Authenticator app'` logged before the code was typed, login
+  reached MONITORING, no regression, no CCP lockout.
+- **Mismatch / fail-loud path is unit-tested + code-verified, not yet
+  exercised live** (would require an account defaulting to a non-TOTP
+  method). It is strictly safe: a positive mismatch returns False with
+  `ALERT_2FA_FAILED`, and any unrecognized case falls through to the
+  prior behavior — it cannot regress a working login.
 
 ## [0.6.3] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,16 +53,22 @@ and the project follows [Semantic Versioning](https://semver.org/).
 
 ### Validation
 
-- 235 unit tests pass, incl. new coverage for `_resolve_twofa_device`,
-  `_twofa_requested_method`, and `_twofa_method_mismatch` (match,
-  positive-mismatch, and the lenient no-prompt/no-desired cases that
-  guarantee no single-method regression).
-- `make test` green end-to-end (agent compile + manifest + py_compile +
-  tests). No Java agent change in this release — the fix is pure Python
+- 237 unit tests pass, incl. coverage for `_resolve_twofa_device`,
+  `_twofa_requested_method` (incl. window-scoped extraction from a
+  realistic full label set), and `_twofa_method_mismatch` (match,
+  positive-mismatch, lenient no-prompt/no-desired — guaranteeing no
+  single-method regression).
+- `make test` green end-to-end. No Java agent change — pure Python,
   reusing the existing `LABELS` command.
-- **Held until validated against the futures-admin multi-method
-  account** (confirm the match case still logs in, and the mismatch
-  case produces the clear failure). `[0.7.0]` date set at release.
+- The prompt is read via `agent_labels()` (no arg) and scoped by window
+  TITLE in `_twofa_requested_method(window_substr=...)`. A first spike
+  (rc1) showed the detection didn't engage because the call passed the
+  window substring to `agent_labels()`, which filters by label TEXT —
+  the prompt text doesn't contain "Second Factor", so it was dropped.
+  Fixed; the agent's recursive label walk does reach the nested prompt.
+- **Held until a confirmation spike** on the futures-admin multi-method
+  account shows the detection engaging (the "method prompt … matches …"
+  line) with login still completing. `[0.7.0]` date set at release.
 
 ## [0.6.3] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [0.7.0] - unreleased (pending futures-admin validation)
+
+### Fixed
+
+- **Multi-method 2FA no longer mis-types the TOTP into the wrong method
+  (issue #7).** On an IBKR account with more than one second-factor
+  method enabled, Gateway pre-defaults the Second Factor dialog to one
+  method and shows an "Enter `<method>` code" prompt. Previously the
+  controller typed the TOTP regardless of which method the dialog was
+  asking for — so if Gateway defaulted to IB Key (not the TOTP/Mobile
+  Authenticator method), the code went into the wrong control and login
+  failed silently. The controller now **reads the dialog's method
+  prompt** and:
+  - types the code when the prompt matches the method `TWOFACTOR_CODE`
+    satisfies (default `Mobile Authenticator app`, overridable via the
+    IBC-compatible `TWOFA_DEVICE`); else
+  - **fails loudly** with `ALERT_2FA_FAILED reason="2FA method mismatch"`
+    and a remediation line (set your IBKR preferred method), instead of
+    mis-typing.
+  - **Lenient by design:** an unrecognized or absent prompt falls
+    through to the existing "type the code" behavior, so single-method
+    accounts and any dialog wording we don't recognize are unchanged —
+    no regression.
+
+  Scope note: this fixes the *silent failure* and gives clear guidance.
+  Automated *switching* to a non-default method (driving Gateway's
+  "Change input method" control) is **not** included — a live spike
+  (2026-05-29) established that the real 10.45.1c UI is a defaulted code
+  dialog + a hidden "Change input method" link, not the JList chooser an
+  earlier draft assumed; driving that control needs data we don't yet
+  have. Tracked under #7.
+
+### Security
+
+- **launcher.log diagnostic echo now redacts account numbers.** The
+  auth-failure diagnostic logs the last 10 lines of Gateway's
+  `launcher.log` at ERROR; those lines now pass through `_redact_logs`
+  (DU/U account-number masking). Gateway already redacts the password
+  in launcher.log, so this closes the residual account-number exposure
+  in a path that fires exactly when users collect logs for a bug report.
+
+### Changed
+
+- `TWOFA_DEVICE` is now honored (the method-match check above) instead of
+  being a silent no-op; the prior misleading comment in
+  `_warn_unsupported_env_vars()` is corrected.
+
+### Validation
+
+- 235 unit tests pass, incl. new coverage for `_resolve_twofa_device`,
+  `_twofa_requested_method`, and `_twofa_method_mismatch` (match,
+  positive-mismatch, and the lenient no-prompt/no-desired cases that
+  guarantee no single-method regression).
+- `make test` green end-to-end (agent compile + manifest + py_compile +
+  tests). No Java agent change in this release — the fix is pure Python
+  reusing the existing `LABELS` command.
+- **Held until validated against the futures-admin multi-method
+  account** (confirm the match case still logs in, and the mismatch
+  case produces the clear failure). `[0.7.0]` date set at release.
+
 ## [0.6.3] - 2026-05-11
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make
 make install DESTDIR=/home/ibgateway
 
 # Create a release tarball
-make release VERSION=0.6.3
+make release VERSION=0.7.0
 ```
 
 Requires JDK 17+ (`javac` + `jar`) and `make`. No Maven, no Gradle.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Version is overridable on the command line:
 #   make release VERSION=0.2.0
 
-VERSION          ?= 0.6.3
+VERSION          ?= 0.7.0
 NAME             := ibg-controller
 DIST             := dist
 AGENT_SRC        := agent/GatewayInputAgent.java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d --name ibkr \
 ```
 
 Tags published: `:latest`, `:<major>.<minor>` (e.g. `:0.5`), and
-`:v<major>.<minor>.<patch>` (e.g. `:v0.6.3`). Every tag is signed with
+`:v<major>.<minor>.<patch>` (e.g. `:v0.7.0`). Every tag is signed with
 cosign via Sigstore keyless signing — see [`SECURITY.md`](SECURITY.md)
 for the verification recipe. For reproducible deployments, pin to a
 digest (`ghcr.io/code-hustler-ft3d/ibg-controller@sha256:...`) — the
@@ -136,8 +136,9 @@ Quick start above instead.
 | Single-mode paper cold-start | ✅ verified | ⚠️ code in place | TWS code-path unit-tested; app-name match needs real TWS to validate |
 | Single-mode live cold-start | ✅ verified | ⚠️ code in place | |
 | Dual mode (`TRADING_MODE=both`) | ✅ verified | ⚠️ code in place | Per-instance state isolation, agent sockets, ready files, JVM-PID-scoped find_app |
-| TOTP 2FA | ✅ verified | ⚠️ code in place | |
-| IB Key push 2FA | ✅ wait mode | ✅ wait mode | Controller detects the 2FA dialog, logs "approve on your phone", polls for dialog dismissal. User approves via IB Key mobile app. Same approach as ibctl. |
+| TOTP 2FA (single method) | ✅ verified | ⚠️ code in place | |
+| IB Key push 2FA (single method) | ✅ wait mode | ✅ wait mode | Controller detects the 2FA dialog, logs "approve on your phone", polls for dialog dismissal. User approves via IB Key mobile app. Same approach as ibctl. |
+| Multi-method 2FA | ⚠️ partial (v0.7.0) | ⚠️ partial | Account with >1 method: Gateway defaults the dialog to one method. If that's the method matching `TWOFACTOR_CODE`, login works. If not, the controller now **fails clearly** (no silent mis-type) and tells you to set your IBKR preferred method — automated method-switching is not yet implemented. See [issue #7](https://github.com/code-hustler-ft3d/ibg-controller/issues/7). |
 | Existing-session dialog | ✅ verified | ⚠️ code in place | Clicks `Continue Login`; late-arrival handler catches the dialog if it shows during the 2FA wait |
 | `TWS_MASTER_CLIENT_ID` | ✅ verified | ⚠️ untested | Set + read back |
 | `READ_ONLY_API` | ✅ verified | ⚠️ untested | Set + read back via JCHECK |
@@ -224,6 +225,7 @@ Full diagnostic history and architectural reasoning: [`docs/ARCHITECTURE.md`](do
 | `TRADING_MODE` | `live`, `paper`, or `both` (default: `paper`). `both` runs two Gateway JVMs in parallel with isolated state. |
 | `TWOFACTOR_CODE` | Base32 TOTP secret from IBKR Mobile Authenticator setup. When set, the controller generates a TOTP code and enters it into the Second Factor Authentication dialog. |
 | `TWOFACTOR_CODE_FILE` | Alternative: read the TOTP secret from a file (Docker secrets pattern). |
+| `TWOFA_DEVICE` | IBC-compatible. Only relevant if your IBKR account has **more than one** 2FA method enabled. Names the method `TWOFACTOR_CODE` satisfies — defaults to `Mobile Authenticator app`. The controller checks Gateway's 2FA prompt against this; if Gateway defaulted to a different method it fails clearly rather than mis-typing the code. Ignored on single-method accounts. v0.7.0+ ([issue #7](https://github.com/code-hustler-ft3d/ibg-controller/issues/7)). |
 
 ### 2FA timeout behavior (IBC-compat)
 | Var | Notes |

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,6 +76,33 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
+### v0.7.0
+
+**Multi-method 2FA fix (issue #7) + a small log-redaction hardening.**
+
+If your IBKR account has a **single** 2FA method: nothing changes.
+
+If your account has **more than one** 2FA method (e.g. IB Key + Mobile
+Authenticator), Gateway defaults the login dialog to one of them. The
+controller now reads which method the dialog is asking for and:
+- **types the TOTP only if it matches** the method `TWOFACTOR_CODE`
+  satisfies (default: Mobile Authenticator). This is the case that
+  already worked — it still works.
+- **fails clearly if Gateway defaulted to a different method**, with
+  `ALERT_2FA_FAILED reason="2FA method mismatch"` and a remediation
+  line — instead of silently typing the code into the wrong method
+  (the old behavior that produced the #7 failure).
+
+**If you hit the mismatch failure:** set your IBKR account's preferred
+2FA method to the one matching `TWOFACTOR_CODE` (Mobile Authenticator),
+so Gateway defaults to it. Automated *switching* away from Gateway's
+default is not implemented yet (the dialog's switch control is a hidden
+link we haven't been able to drive safely — see #7). You can also set
+`TWOFA_DEVICE` if your dialog's method wording differs from the default.
+
+This release is pure Python (no agent-jar change), but pulling the new
+image is the normal upgrade path.
+
 ### v0.6.3
 
 **Security fix — upgrade recommended.** A plaintext IBKR password

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -49,7 +49,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from zoneinfo import ZoneInfo
 
 
-__version__ = "0.6.3"
+__version__ = "0.7.0"
 
 # Wall-clock timestamp recorded when the controller module loads. Reported
 # by the /health endpoint as `uptime_seconds` so monitoring can spot a
@@ -1424,6 +1424,62 @@ def handle_existing_session_dialog():
     return False
 
 
+def _resolve_twofa_device(explicit, has_totp):
+    """Resolve which second-factor method we expect Gateway's 2FA dialog
+    to be requesting. Explicit ``TWOFA_DEVICE`` wins; otherwise default to
+    the Mobile Authenticator (TOTP) method when a TOTP secret is
+    configured, else IB Key. IBC-compatible (``SecondFactorDevice``).
+    """
+    explicit = (explicit or "").strip()
+    if explicit:
+        return explicit
+    return "Mobile Authenticator app" if has_totp else "IB Key"
+
+
+def _twofa_requested_method(labels):
+    """From ``agent_labels()`` output (a list of ``(window_title, text)``
+    tuples) return Gateway's 2FA method-prompt label — IBKR phrases it as
+    "Enter <method> code" — or ``None`` if no such label is present.
+
+    On a multi-method account Gateway pre-defaults the Second Factor
+    dialog to ONE method and shows this prompt; reading it tells us which
+    method the dialog is actually expecting.
+    """
+    for _, text in labels:
+        t = (text or "").strip()
+        tl = t.lower()
+        if tl.startswith("enter ") and tl.endswith(" code"):
+            return t
+    return None
+
+
+def _twofa_method_mismatch(prompt, desired_device):
+    """Return True only if ``prompt`` ("Enter <method> code") positively
+    names a method OTHER than ``desired_device``.
+
+    Deliberately lenient — returns False whenever we can't be sure (no
+    recognizable prompt, empty desired, or a match), so single-method
+    accounts and any dialog wording we don't recognize keep the existing
+    "just type the code" behavior. We only block when we POSITIVELY
+    detect the dialog is asking for a different method than the one we
+    can satisfy, to avoid typing a TOTP into the wrong method (issue #7).
+    """
+    if not prompt:
+        return False
+    d = (desired_device or "").strip().lower()
+    if not d:
+        return False
+    p = prompt.lower()
+    if d in p:
+        return False
+    # Fall back to the distinctive head token (e.g. "mobile authenticator"),
+    # so minor wording drift in the env value still matches the prompt.
+    head = " ".join(d.split()[:2])
+    if head and head in p:
+        return False
+    return True
+
+
 def handle_2fa(app):
     """Handle Gateway's Second Factor Authentication dialog.
 
@@ -1468,6 +1524,15 @@ def handle_2fa(app):
     ib_key_mode = not TOTP_SECRET
     if ib_key_mode:
         log.info("No TWOFACTOR_CODE set — will watch for IB Key push dialog if it appears")
+
+    # v0.7.0 (issue #7): the method we can satisfy. On a multi-method
+    # account Gateway pre-defaults the 2FA dialog to one method; we read
+    # the dialog's "Enter <method> code" prompt and only type the TOTP if
+    # it's asking for this method, rather than mis-typing into the wrong
+    # one. Defaults to Mobile Authenticator in TOTP mode (IBC-compatible
+    # TWOFA_DEVICE override).
+    twofa_device = _resolve_twofa_device(os.environ.get("TWOFA_DEVICE"),
+                                         bool(TOTP_SECRET))
 
     # IBC-compat 2FA timeout configuration:
     #   TWOFA_EXIT_INTERVAL   — seconds to wait for the dialog (default 120)
@@ -1573,6 +1638,37 @@ def handle_2fa(app):
             else:
                 # TOTP mode: type the code and click OK
                 log.info(f"2FA dialog detected: {two_fa_window}")
+                # v0.7.0 (issue #7): on a multi-method account Gateway's
+                # dialog is pre-defaulted to one method and shows an
+                # "Enter <method> code" prompt. Only type our TOTP if the
+                # dialog is asking for the method we can satisfy; if it
+                # POSITIVELY names a different method, fail loudly with
+                # remediation instead of mis-typing the code (the silent
+                # failure reported in #7). Lenient: an unrecognized /
+                # absent prompt falls through to the existing behavior,
+                # so single-method accounts are unaffected.
+                prompt = _twofa_requested_method(agent_labels(TWOFA_WINDOW_SUBSTR))
+                if _twofa_method_mismatch(prompt, twofa_device):
+                    log.error(
+                        f"2FA dialog is requesting a different method than "
+                        f"configured: prompt={prompt!r}, expected "
+                        f"{twofa_device!r}. NOT entering the TOTP code into "
+                        f"the wrong method.")
+                    log.error(
+                        f"ALERT_2FA_FAILED mode={TRADING_MODE} "
+                        f"reason=\"2FA method mismatch\" "
+                        f"dialog_prompt={prompt!r} expected={twofa_device!r}")
+                    log.error(
+                        "Remediation: this account has multiple 2FA methods "
+                        "and Gateway defaulted to one ibg-controller can't "
+                        "drive automatically yet. Set your IBKR account's "
+                        f"preferred 2FA method to {twofa_device!r} (the one "
+                        "matching TWOFACTOR_CODE). See docs/UPGRADING.md "
+                        "(issue #7).")
+                    return False
+                if prompt:
+                    log.info(f"2FA method prompt {prompt!r} matches "
+                             f"{twofa_device!r}")
                 code = generate_totp(TOTP_SECRET)
                 log.info(f"Typing TOTP code into the 2FA dialog")
                 if not agent_settext_in_window(TWOFA_WINDOW_SUBSTR, code):
@@ -2928,7 +3024,10 @@ def _diagnose_login_failure():
                  if line and "DeadlockMonitor" not in line
                  and "AdManager" not in line]
         for line in lines[-10:]:
-            log.error(f"    {line}")
+            # Gateway redacts the password in launcher.log, but account
+            # numbers (DU/U) can appear; run through _redact_logs since
+            # this fires on auth failure — exactly when users grab logs.
+            log.error(f"    {_redact_logs(line)}")
         return
 
     if has_timeout and not has_ns_auth_start:
@@ -3238,10 +3337,10 @@ def _warn_unsupported_env_vars():
     #   BYPASS_WARNING  → _resolve_safe_dismiss_buttons() extends the
     #                     disclaimer allowlist at module load
     #   TWS_COLD_RESTART → apply_warm_state() skips when set
-    # TWOFA_DEVICE is no longer in this list: the controller handles
-    # IB Key push 2FA by polling for the dialog to disappear (the user
-    # approves on their phone, the dialog goes away, we proceed). Same
-    # approach as ibctl. Not as hands-free as TOTP but not impossible.
+    # TWOFA_DEVICE is honored as of v0.7.0 (issue #7): handle_2fa()
+    # reads Gateway's "Enter <method> code" prompt and refuses to type
+    # the TOTP if the dialog is asking for a different method than
+    # TWOFA_DEVICE names. Not warned.
     unsupported = {
         "CUSTOM_CONFIG":
             "not honored; the controller reads env vars directly and "

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -1436,7 +1436,7 @@ def _resolve_twofa_device(explicit, has_totp):
     return "Mobile Authenticator app" if has_totp else "IB Key"
 
 
-def _twofa_requested_method(labels):
+def _twofa_requested_method(labels, window_substr=None):
     """From ``agent_labels()`` output (a list of ``(window_title, text)``
     tuples) return Gateway's 2FA method-prompt label — IBKR phrases it as
     "Enter <method> code" — or ``None`` if no such label is present.
@@ -1444,8 +1444,18 @@ def _twofa_requested_method(labels):
     On a multi-method account Gateway pre-defaults the Second Factor
     dialog to ONE method and shows this prompt; reading it tells us which
     method the dialog is actually expecting.
+
+    ``window_substr`` scopes the search to labels whose window title
+    contains it. Pass it the 2FA window substring. NOTE: this is the
+    window-title scope — do NOT rely on ``agent_labels(<substr>)`` for
+    it, because that filters by label TEXT, not window title (which
+    silently dropped the prompt in v0.7.0-rc1; the prompt text doesn't
+    contain "Second Factor"). Always call ``agent_labels()`` with no
+    argument and scope here.
     """
-    for _, text in labels:
+    for w, text in labels:
+        if window_substr and window_substr not in (w or ""):
+            continue
         t = (text or "").strip()
         tl = t.lower()
         if tl.startswith("enter ") and tl.endswith(" code"):
@@ -1647,7 +1657,19 @@ def handle_2fa(app):
                 # failure reported in #7). Lenient: an unrecognized /
                 # absent prompt falls through to the existing behavior,
                 # so single-method accounts are unaffected.
-                prompt = _twofa_requested_method(agent_labels(TWOFA_WINDOW_SUBSTR))
+                #
+                # NOTE: agent_labels() filters by label TEXT, not window
+                # title — so we fetch ALL labels (no filter) and scope to
+                # the Second Factor window via the returned window-title.
+                # Poll briefly in case the prompt JLabel renders a beat
+                # after the dialog window appears.
+                prompt = None
+                for _ in range(3):
+                    prompt = _twofa_requested_method(
+                        agent_labels(), window_substr=TWOFA_WINDOW_SUBSTR)
+                    if prompt:
+                        break
+                    time.sleep(0.5)
                 if _twofa_method_mismatch(prompt, twofa_device):
                     log.error(
                         f"2FA dialog is requesting a different method than "

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # running ibgateway container's filesystem.
 #
 # Usage (from the docker image's setup stage):
-#   ARG IBG_CONTROLLER_VERSION=0.6.3
+#   ARG IBG_CONTROLLER_VERSION=0.7.0
 #   RUN curl -sSLO https://github.com/code-hustler-ft3d/ibg-controller/releases/download/v${IBG_CONTROLLER_VERSION}/ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       tar -xzf ibg-controller-${IBG_CONTROLLER_VERSION}.tar.gz && \
 #       cd ibg-controller-${IBG_CONTROLLER_VERSION} && \

--- a/tests/test_pure_logic.py
+++ b/tests/test_pure_logic.py
@@ -2033,5 +2033,65 @@ class TestRecoverJvmMaintenanceGuard(unittest.TestCase):
         mock_delay.assert_not_called()
 
 
+class TestResolveTwofaDevice(unittest.TestCase):
+    def test_explicit_wins(self):
+        self.assertEqual(gc._resolve_twofa_device("IB Key", True), "IB Key")
+        self.assertEqual(
+            gc._resolve_twofa_device("  Mobile Authenticator app  ", False),
+            "Mobile Authenticator app")
+
+    def test_default_totp(self):
+        self.assertEqual(gc._resolve_twofa_device("", True),
+                         "Mobile Authenticator app")
+        self.assertEqual(gc._resolve_twofa_device(None, True),
+                         "Mobile Authenticator app")
+
+    def test_default_non_totp(self):
+        self.assertEqual(gc._resolve_twofa_device("", False), "IB Key")
+        self.assertEqual(gc._resolve_twofa_device("   ", False), "IB Key")
+
+
+class TestTwofaRequestedMethod(unittest.TestCase):
+    def test_finds_enter_method_code_label(self):
+        labels = [("Second Factor Authentication", "Some heading"),
+                  ("Second Factor Authentication", "Enter Mobile Authenticator app code")]
+        self.assertEqual(gc._twofa_requested_method(labels),
+                         "Enter Mobile Authenticator app code")
+
+    def test_none_when_no_prompt(self):
+        labels = [("Second Factor Authentication", "Please authenticate"),
+                  ("Second Factor Authentication", "OK")]
+        self.assertIsNone(gc._twofa_requested_method(labels))
+
+    def test_none_on_empty(self):
+        self.assertIsNone(gc._twofa_requested_method([]))
+
+
+class TestTwofaMethodMismatch(unittest.TestCase):
+    def test_match_is_not_mismatch(self):
+        self.assertFalse(gc._twofa_method_mismatch(
+            "Enter Mobile Authenticator app code", "Mobile Authenticator app"))
+
+    def test_positive_mismatch(self):
+        # Dialog wants IB Key, we can only do Mobile Authenticator (TOTP).
+        self.assertTrue(gc._twofa_method_mismatch(
+            "Enter IB Key code", "Mobile Authenticator app"))
+
+    def test_lenient_when_no_prompt(self):
+        # Unknown/absent prompt → never block (no regression for
+        # single-method or unrecognized dialogs).
+        self.assertFalse(gc._twofa_method_mismatch(None, "Mobile Authenticator app"))
+        self.assertFalse(gc._twofa_method_mismatch("", "Mobile Authenticator app"))
+
+    def test_lenient_when_no_desired(self):
+        self.assertFalse(gc._twofa_method_mismatch("Enter IB Key code", ""))
+
+    def test_head_token_match(self):
+        # Env value slightly differs from the dialog wording but the
+        # distinctive head token ("mobile authenticator") still matches.
+        self.assertFalse(gc._twofa_method_mismatch(
+            "Enter Mobile Authenticator app code", "Mobile Authenticator"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_pure_logic.py
+++ b/tests/test_pure_logic.py
@@ -2066,6 +2066,29 @@ class TestTwofaRequestedMethod(unittest.TestCase):
     def test_none_on_empty(self):
         self.assertIsNone(gc._twofa_requested_method([]))
 
+    def test_window_scoped_extraction_from_full_label_set(self):
+        # Regression for v0.7.0-rc1: agent_labels() returns labels from
+        # ALL windows; we must scope by window TITLE (not by passing a
+        # title substring to agent_labels, which filters by label text
+        # and silently dropped the prompt). Given the realistic full set,
+        # window-scoping must still find the 2FA prompt.
+        full = [
+            ("IBKR Gateway", "Connecting to server"),
+            ("IBKR Gateway", "Account"),
+            ("Second Factor Authentication", "Enter Mobile Authenticator app code"),
+            ("Second Factor Authentication", "OK"),
+        ]
+        self.assertEqual(
+            gc._twofa_requested_method(full, window_substr="Second Factor"),
+            "Enter Mobile Authenticator app code")
+
+    def test_window_scope_excludes_other_windows(self):
+        # An "Enter ... code" label in some OTHER window must not be
+        # picked when scoping to the 2FA window.
+        labels = [("Some Other Dialog", "Enter card code")]
+        self.assertIsNone(
+            gc._twofa_requested_method(labels, window_substr="Second Factor"))
+
 
 class TestTwofaMethodMismatch(unittest.TestCase):
     def test_match_is_not_mismatch(self):


### PR DESCRIPTION
**Draft / held for one futures-admin validation.** Fixes issue #7. Supersedes PR #8 and PR #10 (closing both).

## What the spike taught us
The 2026-05-29 spike against a real multi-method account **disproved the JList premise** of the earlier draft (PR #10). Gateway 10.45.1c's multi-method 2FA UI is **not** a device-chooser JList — it's a single code dialog **pre-defaulted to one method** ("Enter `<method>` code") with a **hidden "Change input method" link**. IBC has no logic for that link, so automating it would be a blind build — exactly what produced the wrong JList fix.

## The fix (honest, buildable, testable)
Read Gateway's "Enter `<method>` code" prompt and:
- **type the TOTP only if it matches** the method `TWOFACTOR_CODE` satisfies (default `Mobile Authenticator app`, overridable via IBC-compatible `TWOFA_DEVICE`);
- **fail loudly on a positive mismatch** (`ALERT_2FA_FAILED reason="2FA method mismatch"` + remediation) instead of silently typing the code into the wrong method — the actual #7 failure.
- **Lenient:** an unrecognized/absent prompt falls through to the existing type-the-code path → single-method accounts unchanged, **no regression**.

Pure Python, **no agent-jar change** (reuses the existing `LABELS` command). Automated method-*switching* (driving the hidden link) is out of scope — tracked under #7.

## Folded in (so this is ONE clean release, not three)
- **Security:** the launcher.log auth-failure diagnostic echo now runs through `_redact_logs` (account numbers). Gateway already redacts the password there; this closes the residual DU/U exposure in a path that fires when users collect logs.
- `TWOFA_DEVICE` now honored (was a silent no-op); misleading warning comment corrected.

## Test plan
- [x] 235 unit tests (+11: `_resolve_twofa_device`, `_twofa_requested_method`, `_twofa_method_mismatch` incl. the lenient no-regression cases)
- [x] `make test` green end-to-end; `py_compile` OK; agent compiles (unchanged) under JDK 17
- [x] CI (runs on push)
- [ ] **Futures-admin validation (the merge gate):** on the multi-method account, confirm (1) the match case still logs in (default = Mobile Authenticator → code typed → MONITORING), and (2) optionally, flipping the IBKR default produces the clear `ALERT_2FA_FAILED reason="2FA method mismatch"` instead of a silent failure.

## Housekeeping
Closing **PR #8** (the TWOFA_DEVICE warning — superseded; TWOFA_DEVICE is now honored) and **PR #10** (the JList approach — premise disproven by the spike). This branch is the single consolidated v0.7.0.

Closes #7 (pending validation). Refs PR #8, PR #10.