### PR TITLE
docs: 2FA setup guidance for unattended use

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,34 @@ Full diagnostic history and architectural reasoning: [`docs/ARCHITECTURE.md`](do
 | `TWOFACTOR_CODE_FILE` | Alternative: read the TOTP secret from a file (Docker secrets pattern). |
 | `TWOFA_DEVICE` | IBC-compatible. Only relevant if your IBKR account has **more than one** 2FA method enabled. Names the method `TWOFACTOR_CODE` satisfies — defaults to `Mobile Authenticator app`. The controller checks Gateway's 2FA prompt against this; if Gateway defaulted to a different method it fails clearly rather than mis-typing the code. Ignored on single-method accounts. v0.7.0+ ([issue #7](https://github.com/code-hustler-ft3d/ibg-controller/issues/7)). |
 
+### 2FA setup for unattended use (read this if you have a choice of method)
+
+The controller is built for **unattended, headless** operation, and that
+constrains which 2FA method works:
+
+- **Use Mobile Authenticator (TOTP)** — provide the base32 secret via
+  `TWOFACTOR_CODE`. This is the only method a headless container can
+  satisfy on its own.
+- **IB Key push is *not* suitable for unattended use.** It sends a
+  notification you must tap "approve" on, on a phone — there's no one to
+  tap it when a container auto-restarts at 3am. The controller *can*
+  wait for an IB Key approval (leave `TWOFACTOR_CODE` unset and it polls
+  for the dialog to clear), but that only helps if a human is actually
+  there to approve. For true automation, it's a dead end.
+- **If your account has *more than one* method enabled**, Gateway
+  defaults its login dialog to one of them. If it defaults to IB Key,
+  your TOTP can't satisfy that dialog — v0.7.0 detects this and fails
+  with a clear `ALERT_2FA_FAILED reason="2FA method mismatch"` rather
+  than silently entering the code in the wrong place (see
+  [issue #7](https://github.com/code-hustler-ft3d/ibg-controller/issues/7)).
+  The resolution is on the IBKR side: get the login the controller uses
+  to default to (or only have) **Mobile Authenticator**. Manage your
+  methods in **Client Portal → Settings → User Settings → Security →
+  Secure Login System**, or contact **IBKR Client Services (Secure
+  Login dept)**. How IBKR's multi-method defaulting and device
+  management behave is governed entirely by IBKR — confirm against your
+  own account; this project can't change it.
+
 ### 2FA timeout behavior (IBC-compat)
 | Var | Notes |
 |---|---|


### PR DESCRIPTION
Bakes our 2FA methodology into the README so the multi-method question (issue #7) doesn't get relitigated.

**Says (all verified / our own methodology):**
- Headless = **Mobile Authenticator (TOTP)** only — the only method a container can satisfy unattended.
- **IB Key push is a dead end for automation** — needs a human to tap approve; the controller can wait for it, but that only helps if someone's there.
- Multi-method accounts that default to IB Key → v0.7.0 fails clearly (`ALERT_2FA_FAILED reason="2FA method mismatch"`); resolution is IBKR-side (Secure Login System settings / Client Services). Explicitly notes IBKR governs this, not us.

**Deliberately omits** a "dedicated sub-account/username with isolated TOTP" workaround. Verification turned up a counter-signal — IBKR says a security device can be *shared across a person's usernames* ([SLS page](https://www.interactivebrokers.com/en/general/secure-login.php)) — and I could not confirm a separate username gets *independent* 2FA. Left out rather than assert a third unverified IBKR mechanic.

Docs-only, no version bump — rides into the next release. No code touched.