### PR TITLE
chore(license): make LICENSE detect as MIT; attribution to NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,15 +2,6 @@ MIT License
 
 Copyright (c) 2026 ibg-controller contributors
 
-This project builds on work from:
-  - gnzsnz/ib-gateway-docker (Copyright 2022 Emanuel Fernandes, 2023 gnzsnz)
-    — the Docker image this tool was originally extracted from
-  - IbcAlpha/IBC (Copyright the IBC authors)
-    — the Java automation tool this is designed to replace
-  - Lcstyle/ibctl (Copyright Lcstyle)
-    — the Rust+Java prior art whose in-JVM agent architecture inspired
-      this project's Python+Java split
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ release: all
 	@mkdir -p $(DIST)/$(NAME)-$(VERSION)/docs
 	cp $(AGENT_JAR) $(DIST)/$(NAME)-$(VERSION)/gateway-input-agent.jar
 	cp $(DIST)/$(CONTROLLER_PY) $(DIST)/$(NAME)-$(VERSION)/$(CONTROLLER_PY)
-	cp README.md LICENSE CHANGELOG.md SECURITY.md \
+	cp README.md LICENSE NOTICE CHANGELOG.md SECURITY.md \
 	  $(DIST)/$(NAME)-$(VERSION)/
 	cp docs/*.md $(DIST)/$(NAME)-$(VERSION)/docs/
 	cp scripts/install.sh $(DIST)/$(NAME)-$(VERSION)/install.sh

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,32 @@
+ibg-controller — NOTICE
+
+ibg-controller's own code — gateway_controller.py and the in-JVM Java agent
+(agent/GatewayInputAgent.java) — is original work, licensed under the MIT
+License (see LICENSE).
+
+This project builds on, and is distributed on top of, work from others:
+
+- gnzsnz/ib-gateway-docker — MIT License
+  (Copyright 2022 Emanuel Fernandes; Copyright 2023 gnzsnz)
+  The shipped Docker image is built FROM ghcr.io/gnzsnz/ib-gateway, and
+  docker/run.sh is DERIVED from that project's run.sh — it sources the
+  upstream common.sh and reuses its helper functions (file_env,
+  apply_settings, set_ports, port_forwarding, wait_x_socket, ...). The
+  upstream MIT copyright notice is preserved here and in docker/run.sh.
+
+- IbcAlpha/IBC — GPLv3
+  (Copyright the IBC authors)
+  The Java automation tool that ibg-controller is designed to REPLACE.
+  ibg-controller is an independent reimplementation; it does NOT include,
+  copy, link, or distribute any IBC source code or the IBC.jar. Knowledge
+  of Gateway's dialogs was informed by reading IBC, but no IBC code is
+  used — so ibg-controller carries no GPL obligation from IBC.
+
+- Lcstyle/ibctl
+  (Copyright Lcstyle)
+  Rust + Java prior art whose in-JVM-agent architecture inspired this
+  project's Python + Java split. No ibctl source code is included.
+
+Trademarks: "Interactive Brokers", "IB Gateway", "Trader Workstation",
+"TWS", and "IB Key" are trademarks of Interactive Brokers LLC. This project
+is not affiliated with or endorsed by Interactive Brokers.

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # shellcheck disable=SC2317
 # Don't warn about unreachable commands in this file
+#
+# Derived from gnzsnz/ib-gateway-docker's run.sh (MIT License,
+# Copyright 2022 Emanuel Fernandes, 2023 gnzsnz). This variant swaps the
+# upstream IBC-first dispatch for the ibg-controller path; it still
+# sources the upstream common.sh and reuses its helpers (file_env,
+# apply_settings, set_ports, port_forwarding, wait_x_socket, ...).
+# See NOTICE.
 
 set -Eeo pipefail
 


### PR DESCRIPTION
GitHub was classifying the repo as license **"Other"** (not MIT) — despite the MIT header and the README MIT badge — because an upstream-attribution block sat between the MIT copyright line and the permission grant, breaking GitHub's template match. We're fully downstream of gnzsnz at the packaging layer (image `FROM` + `run.sh` derived from theirs), and gnzsnz is **MIT**, so this is permissive — just attribution hygiene, no copyleft.

- **LICENSE** → canonical MIT text (GitHub will now detect "MIT", matching the badge).
- **NOTICE** (new) → upstream attribution: gnzsnz/ib-gateway-docker (MIT, © 2022 Emanuel Fernandes / 2023 gnzsnz — image base + the `run.sh` derivation), IbcAlpha/IBC (GPLv3, *replaced not included* — no GPL obligation), Lcstyle/ibctl (architecture inspiration), plus an IBKR trademark note.
- **docker/run.sh** → header crediting gnzsnz's run.sh (MIT), where the derivation actually lives (it sources upstream `common.sh` + reuses its helpers).
- **Makefile** → ships `NOTICE` in the release tarball alongside `LICENSE`.

Net: attribution is *stronger* (NOTICE + run.sh header + README Acknowledgements), the run.sh derivation is airtight, and the repo reads "MIT" cleanly. Docs/licensing only — no code, no release.

Validated: `bash -n docker/run.sh` OK; `make release` builds with NOTICE in the tarball; LICENSE is canonical MIT.