### PR TITLE
docs: add Scope section (headless Docker Gateway, gnzsnz upstream)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ re-authentication events, and exposes IBC's TCP command server.
 > community of `gnzsnz/ib-gateway-docker` can read, patch, and extend
 > it without a JVM or Rust toolchain.
 
+## Scope
+
+ibg-controller **targets headless Docker IB Gateway** and **favors
+[`gnzsnz/ib-gateway-docker`](https://github.com/gnzsnz/ib-gateway-docker)**
+as its base: the shipped image builds `FROM` it and `docker/run.sh`
+extends its scaffolding. `UPSTREAM_IMAGE` is a build arg so it isn't
+hard-locked, but gnzsnz's image is the path ibg-controller is built,
+tested, and maintained for.
+
 ## Quick start
 
 The fastest way to use `ibg-controller` is the pre-built image on


### PR DESCRIPTION
Adds a short, plain **Scope** statement up top: ibg-controller targets headless Docker IB Gateway and favors `gnzsnz/ib-gateway-docker` as its base (image builds `FROM` it, `docker/run.sh` extends its scaffolding; `UPSTREAM_IMAGE` is a build arg but gnzsnz is the built/tested/maintained path).

Just states the claim — no hedging, nothing else touched. Docs only, no release.