### PR TITLE
chore(image): self-report bundled IB Gateway version via OCI labels

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -139,8 +139,12 @@ jobs:
           # don't silently track `:stable`. Bump this in lockstep with a
           # deliberate Gateway-version upgrade. Multi-arch manifest (amd64
           # + arm64) as of 10.45.1c, sha256:b4ede80…
+          # IB_GATEWAY_VERSION feeds the com.ibg-controller.ib-gateway-version
+          # image label — keep it in lockstep with the digest pin above so a
+          # `docker inspect` reports the exact bundled Gateway build.
           build-args: |
             UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1c@sha256:b4ede803caf48279b4bdc21c8de1fb19edaef8bedbb2b49153e72b042f660bf3
+            IB_GATEWAY_VERSION=10.45.1c
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Embed buildx provenance so `docker buildx imagetools inspect`

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,19 @@
 ARG UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:stable
 FROM ${UPSTREAM_IMAGE}
 
+# Re-declare post-FROM so they're in scope for the LABEL below (a build ARG
+# declared before FROM is only visible to the FROM instruction itself).
+ARG UPSTREAM_IMAGE
+ARG IB_GATEWAY_VERSION=unknown
+
+# Self-describing image: record the bundled IB Gateway version and the exact
+# upstream base so `docker inspect` (and the GHCR page) report them without
+# starting the container. The release workflow passes the real
+# IB_GATEWAY_VERSION, kept in lockstep with the digest-pinned UPSTREAM_IMAGE;
+# local builds that don't set it report "unknown".
+LABEL com.ibg-controller.ib-gateway-version="${IB_GATEWAY_VERSION}" \
+      org.opencontainers.image.base.name="${UPSTREAM_IMAGE}"
+
 USER root
 
 # Runtime packages. `gettext-base socat xvfb x11vnc sshpass openssh-client


### PR DESCRIPTION
## What

Makes the published image self-describing about its bundled IB Gateway build:

- `Dockerfile` — adds an `IB_GATEWAY_VERSION` build-arg and two labels:
  - `com.ibg-controller.ib-gateway-version` (e.g. `10.45.1c`)
  - `org.opencontainers.image.base.name` (the exact `UPSTREAM_IMAGE` ref+digest)
- `release-image.yml` — passes `IB_GATEWAY_VERSION=10.45.1c`, kept in lockstep with the existing digest pin.

## Why

Prompted by #15: the only way to learn which IB Gateway version an image ships was to start the container and read `Jts/ibgateway`. After this, `docker inspect ghcr.io/code-hustler-ft3d/ibg-controller:0.7` reports it directly, and so does the GHCR page.

## Notes

- Takes effect on the next release build (v0.7.x); existing published images are unchanged.
- Local builds that don't pass the arg report `ib-gateway-version=unknown` — by design.
- Pairs with the v0.7.0 release notes now stating the bundled Gateway version, and the CI matrix build already exercises the Dockerfile so the new ARG/LABEL is covered.
