### PR TITLE
chore(image): bump upstream Gateway pin 10.45.1c → 10.45.1g

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,15 +143,15 @@ jobs:
     # (JRE path, apt package rename, userid shift) before users do.
     #
     # The matrix covers the two Gateway versions we actively verify
-    # against — the prior stable (10.44.1g) and the current stable
-    # (10.45.1c). Add a new entry here when bumping verified versions
-    # in README.md / docs/FROM_IBC.md.
+    # against — the previously shipped pin (10.45.1c) and the current
+    # stable now pinned in release-image.yml (10.45.1g). Add a new entry
+    # here when bumping verified versions in README.md / docs/FROM_IBC.md.
     strategy:
       fail-fast: false
       matrix:
         upstream:
-          - ghcr.io/gnzsnz/ib-gateway:10.44.1g
           - ghcr.io/gnzsnz/ib-gateway:10.45.1c
+          - ghcr.io/gnzsnz/ib-gateway:10.45.1g
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -138,13 +138,13 @@ jobs:
           # Pin the upstream Gateway base by digest so published releases
           # don't silently track `:stable`. Bump this in lockstep with a
           # deliberate Gateway-version upgrade. Multi-arch manifest (amd64
-          # + arm64) as of 10.45.1c, sha256:b4ede80…
+          # + arm64) as of 10.45.1g, sha256:827d7a5…
           # IB_GATEWAY_VERSION feeds the com.ibg-controller.ib-gateway-version
           # image label — keep it in lockstep with the digest pin above so a
           # `docker inspect` reports the exact bundled Gateway build.
           build-args: |
-            UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1c@sha256:b4ede803caf48279b4bdc21c8de1fb19edaef8bedbb2b49153e72b042f660bf3
-            IB_GATEWAY_VERSION=10.45.1c
+            UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1g@sha256:827d7a5b8454ec19cff2abe0ae6983f15bde4a11c5d5dff4cd74d67ace85a3f2
+            IB_GATEWAY_VERSION=10.45.1g
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Embed buildx provenance so `docker buildx imagetools inspect`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- **Upstream Gateway pin bumped 10.45.1c → 10.45.1g.** Both are on
+  gnzsnz's `:stable` line (`:stable` resolved to 10.45.1g at the time of
+  this change); the previous pin had fallen a few patch revisions behind.
+  Same 10.45 minor, so dialog behavior is unchanged — the 2FA/login UI
+  was validated on 10.45.1c and the CI build matrix now exercises both
+  10.45.1c and 10.45.1g.
+
+### Added
+
+- **Image now self-reports its bundled Gateway version (#15, #16).**
+  The release image carries a `com.ibg-controller.ib-gateway-version`
+  label (plus `org.opencontainers.image.base.name`), so
+  `docker inspect` and the GHCR page show the bundled IB Gateway build
+  without starting the container. Release notes also state the version
+  from now on.
+
 ## [0.7.0] - 2026-05-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ make
 # Build the image. UPSTREAM_IMAGE defaults to ghcr.io/gnzsnz/ib-gateway:stable
 # (a moving tag). For reproducible production builds, pin a digest:
 docker build -t ibg-controller:local \
-  --build-arg UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1c@sha256:... \
+  --build-arg UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1g@sha256:... \
   .
 ```
 
@@ -132,7 +132,7 @@ Quick start above instead.
 | Requirement | Notes |
 |---|---|
 | **Linux** | `amd64` and `arm64`. Ubuntu 24.04 base tested. |
-| **IB Gateway** | Tested on **10.45.1c**. Should work on any 10.x with a compatible install4j launcher and a Zulu JRE 17+. |
+| **IB Gateway** | Release images pin **10.45.1g** (gnzsnz `:stable` line); dialog behavior validated on **10.45.1c** of the same line. Should work on any 10.x with a compatible install4j launcher and a Zulu JRE 17+. |
 | **Python 3.10+** | For f-strings with `=` and type hints. |
 | **JDK 17+** | Only at *build* time, for the agent. Runtime uses Gateway's bundled Zulu JRE. |
 | **Ubuntu packages** | `python3 matchbox-window-manager` (matchbox provides focus routing for Xvfb; Xvfb itself ships in the upstream `gnzsnz/ib-gateway` image) |


### PR DESCRIPTION
## What

Bumps the digest-pinned upstream Gateway base **10.45.1c → 10.45.1g** (current gnzsnz `:stable`):

- `release-image.yml` — `UPSTREAM_IMAGE` digest + `IB_GATEWAY_VERSION` label → `10.45.1g` (`sha256:827d7a5b…`, multi-arch amd64+arm64, verified).
- `ci.yml` — build matrix now covers `10.45.1c` (previously shipped) **and** `10.45.1g` (new pin).
- `README.md` — requirements row + build example.
- `CHANGELOG.md` — `[Unreleased]` section covering this bump and the OCI-label work from #16.

## Why

The pin had drifted a few patch revisions behind stable. Both versions are on the same **10.45 stable line**, so login/2FA dialog behavior is unchanged — the UI was live-validated on 10.45.1c and the CI build matrix exercises both.

## Notes

- Takes effect on the next release build; existing published images unchanged.
- README intentionally keeps "dialog behavior validated on 10.45.1c" rather than claiming re-validation on 10.45.1g — prod will exercise 10.45.1g when the next release is cut.
