### PR TITLE
feat: detect IBKR "Invalid username or password" credential-rejection modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and the project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Login now recognizes the "Invalid username or password"
+  credential-rejection modal.** `handle_post_login_dialogs` previously
+  left this dialog unhandled and let it fall through; it now emits the
+  existing `ALERT_LOGIN_FAILED reason="bad-credentials"` grep-contract
+  token and dismisses the modal so the normal CCP-backoff login retry
+  proceeds (detection is a signal, not a corrective abort). The in-JVM
+  relogin path (`attempt_inplace_relogin`) recognizes the same wording
+  too. Gap spotted via @efJerryYang's fork; implemented independently.
 - **Image now self-reports its bundled Gateway version (#15, #16).**
   The release image carries a `com.ibg-controller.ib-gateway-version`
   label (plus `org.opencontainers.image.base.name`), so

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -283,12 +283,18 @@ ALERT_LOGIN_FAILED mode=live reason="bad-credentials" suggested_action="IBKR rej
 ALERT_LOGIN_FAILED mode=live reason="post-auth-no-progress" suggested_action="server accepted the auth handshake but login never completed; verify TWS_USERID / TWS_PASSWORD (or _PAPER variants) and scan logs for an unrecognized post-auth dialog"
 ```
 
-**When fired**: two distinct code paths, both emitting the same
-grep-contract token with different `reason=` values:
+**When fired**: three code paths, all emitting the same grep-contract
+token (`reason=` distinguishes them):
 
+- `reason="bad-credentials"` from `handle_post_login_dialogs` — initial
+  post-login path; Gateway popped the "Invalid username or password"
+  credential-rejection modal. The controller dismisses it and lets the
+  normal login retry proceed (same suggested_action wording as the
+  `attempt_inplace_relogin` modal case below).
 - `reason="bad-credentials"` from `attempt_inplace_relogin` — Gateway
-  popped a visible "Login failed" / "Authentication failed" modal
-  during re-auth; the controller dismisses it and retries.
+  popped a visible "Login failed" / "Authentication failed" / "Invalid
+  username or password" modal during re-auth; the controller dismisses
+  it and retries.
 - `reason="bad-credentials"` from `_diagnose_login_failure` — terminal
   initial-login path, `launcher.log` shows `NS_AUTH_START` *and* a
   `CCP: Timeout!` (handshake completed, credentials rejected at

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -1233,6 +1233,39 @@ def _detect_password_expiry(dump):
     return False, None, None
 
 
+# Credential-rejection modal wording. Gateway surfaces a modal such as
+# "Connection to server failed: Invalid username or password. Please check
+# the Caps Lock key; passwords are case sensitive." when IBKR rejects the
+# supplied login. This is distinct from the launcher.log handshake-timeout
+# diagnosis in _diagnose_login_failure and from the in-JVM relogin marker
+# strings; recognizing the modal lets us emit the ALERT_LOGIN_FAILED
+# grep-contract token at the initial-login stage instead of letting the
+# dialog fall through unrecognized. The alternation also covers the
+# two-word "user name" spelling some IBKR builds use.
+_BAD_CREDENTIALS_MATCH = re.compile(
+    r"(?:"
+    r"(?:invalid|incorrect)\s+user\s?name\s+or\s+password"
+    r"|user\s?name\s+or\s+password\s+(?:is\s+|was\s+)?(?:invalid|incorrect)"
+    r"|credentials?\s+(?:were\s+|was\s+|are\s+|is\s+)?(?:rejected|invalid|incorrect)"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _detect_bad_credentials(dump):
+    """Return True when a dialog reports the login credentials were
+    rejected (Gateway's "Invalid username or password" modal and close
+    variants).
+
+    Detection is a *signal*, not a corrective action (see the Non-goals
+    note in CHANGELOG): the caller emits ALERT_LOGIN_FAILED and dismisses
+    the dialog, then the normal CCP-backoff login retry proceeds.
+    """
+    if not dump:
+        return False
+    return bool(_BAD_CREDENTIALS_MATCH.search(dump))
+
+
 def handle_post_login_dialogs(app):
     """Inspect any modal dialog that appears right after the Log In click,
     handle the ones we recognize, and leave the rest alone.
@@ -1331,6 +1364,29 @@ def handle_post_login_dialogs(app):
                         "dismiss button present; leaving dialog in place")
             else:
                 log.info("Unrecognized 'password' dialog — leaving in place")
+        elif _detect_bad_credentials(dump):
+            log.info("Recognized: credential-rejection dialog")
+            log.error(
+                f"ALERT_LOGIN_FAILED mode={TRADING_MODE} "
+                f"reason=\"bad-credentials\" "
+                f"suggested_action=\"Gateway surfaced a credential-"
+                f"rejection modal; verify TWS_USERID / TWS_PASSWORD "
+                f"(or _PAPER variants) and update env if password "
+                f"was rotated in IBKR Account Settings\"")
+            # Detection is a signal, not a corrective action (see the
+            # Non-goals note in CHANGELOG): dismiss the modal so it
+            # doesn't wedge the post-login flow, then let the normal
+            # login retry / CCP backoff proceed. Do NOT abort here.
+            dismissed = False
+            for btn in ("OK", "Close", "Continue"):
+                if btn in dump and agent_click_in_window(title, btn):
+                    log.info(f"Dismissed credential-rejection dialog via '{btn}'")
+                    dismissed = True
+                    break
+            if not dismissed:
+                log.warning(
+                    "Credential-rejection dialog detected but no known "
+                    "dismiss button present; leaving dialog in place")
         else:
             log.info(f"Unrecognized modal — leaving in place to let Gateway flow proceed")
 
@@ -2829,8 +2885,9 @@ def attempt_inplace_relogin(app):
             "unable to connect",
             "server cannot be reached",
         )
-        is_credential_error = any(
-            m in body_lower for m in credential_error_markers)
+        is_credential_error = (
+            any(m in body_lower for m in credential_error_markers)
+            or _detect_bad_credentials(body))
         is_network_error = any(
             m in body_lower for m in network_error_markers)
         if is_credential_error or is_network_error:

--- a/tests/test_pure_logic.py
+++ b/tests/test_pure_logic.py
@@ -1128,6 +1128,55 @@ class TestDetectPasswordExpiry(unittest.TestCase):
         self.assertIsNone(days)
 
 
+class TestDetectBadCredentials(unittest.TestCase):
+    """_detect_bad_credentials() recognizes Gateway's credential-rejection
+    modal wording ("Invalid username or password" and close variants) so
+    handle_post_login_dialogs / attempt_inplace_relogin can emit the
+    ALERT_LOGIN_FAILED grep-contract token and dismiss the dialog.
+
+    Grep-contract for external monitors (see docs/OBSERVABILITY.md):
+      ALERT_LOGIN_FAILED mode=<live|paper> reason="bad-credentials" suggested_action="..."
+    """
+
+    def test_matches_canonical_invalid_username_or_password_modal(self):
+        dump = ('Connection to server failed: Invalid username or '
+                'password. Please check the Caps Lock key; passwords '
+                'are case sensitive.')
+        self.assertTrue(gc._detect_bad_credentials(dump))
+
+    def test_matches_two_word_user_name_spelling(self):
+        # Some IBKR builds render the two-word "user name".
+        self.assertTrue(gc._detect_bad_credentials(
+            "Invalid user name or password."))
+
+    def test_matches_password_is_incorrect_variant(self):
+        self.assertTrue(gc._detect_bad_credentials(
+            "Username or password is incorrect."))
+
+    def test_matches_credentials_rejected_variant(self):
+        self.assertTrue(gc._detect_bad_credentials(
+            "Connection failed because credentials were rejected."))
+
+    def test_case_insensitive(self):
+        self.assertTrue(gc._detect_bad_credentials(
+            "INVALID USERNAME OR PASSWORD"))
+
+    def test_no_match_on_progress_dialog(self):
+        self.assertFalse(gc._detect_bad_credentials(
+            "Connecting to server. Please wait."))
+
+    def test_no_match_on_password_expiry_wording(self):
+        # Must not collide with the password-expiry branch that runs first.
+        self.assertFalse(gc._detect_bad_credentials(
+            "Your password will expire in 14 days."))
+
+    def test_no_match_on_empty_input(self):
+        self.assertFalse(gc._detect_bad_credentials(""))
+
+    def test_no_match_on_none_input(self):
+        self.assertFalse(gc._detect_bad_credentials(None))
+
+
 class TestResolveSafeDismissButtons(unittest.TestCase):
     """v0.5.1: _resolve_safe_dismiss_buttons() builds the ordered
     dismiss allowlist from BYPASS_WARNING. Returns a tuple so


### PR DESCRIPTION
## What

`handle_post_login_dialogs` previously left IBKR's "Invalid username or password" credential-rejection modal **unhandled** — a wrong-credentials login fell through to the "unrecognized modal, leave in place" branch at the initial-login stage, so no `ALERT_LOGIN_FAILED` fired there.

This adds:

- **`_detect_bad_credentials()`** — a regex detector for the credential-rejection modal wording (including the two-word "user name" spelling some IBKR builds use), mirroring the existing `_detect_password_expiry` style.
- **A recognized branch in `handle_post_login_dialogs`** that emits the existing `ALERT_LOGIN_FAILED reason="bad-credentials"` grep-contract token, dismisses the modal, and lets the normal CCP-backoff retry proceed. **Detection is a signal, not a corrective action** — no `return False`/`sys.exit`, consistent with the documented Non-goal in CHANGELOG.
- **In-JVM relogin path** (`attempt_inplace_relogin`) recognizes the same wording too (purely additive).
- Reuses the **byte-identical** `suggested_action` string (no monitor/grep-contract drift); `docs/OBSERVABILITY.md` updated (two paths → three); CHANGELOG entry.

## Testing

- 9 new unit tests for `_detect_bad_credentials` (canonical modal + variants + negatives); full suite passes (246, up from 237).
- **Unit-validated only — not yet live-validated** against a running Gateway. Fail-safe by design: if the live modal text differs from the regex, behavior degrades to today's "leave unrecognized" (no regression, no bad exit).

## Credit

Gap spotted via @efJerryYang's fork. Implemented independently.