### PR TITLE
Handle 2FA device selector dialog on multi-method accounts (refs #20)

### DIFF
--- a/agent/GatewayInputAgent.java
+++ b/agent/GatewayInputAgent.java
@@ -27,8 +27,11 @@ import javax.accessibility.AccessibleContext;
 import javax.swing.AbstractButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.JTree;
+import javax.swing.ListModel;
 import javax.swing.SwingUtilities;
 import javax.swing.text.JTextComponent;
 import javax.swing.tree.TreeModel;
@@ -42,7 +45,7 @@ import javax.swing.tree.TreePath;
  * INSTALL4J_ADD_VM_PARAMS. Listens on a Unix domain socket with a
  * line-based text protocol, single client at a time, no concurrency.
  *
- * Protocol (v0.2):
+ * Protocol (v0.3):
  *   PING                                  → OK pong
  *   GET_PID                               → OK <jvm_pid>
  *   SETTEXT <name> <text...>              → OK | ERR ...
@@ -55,6 +58,7 @@ import javax.swing.tree.TreePath;
  *   SETTEXT_IN_WIN <title>|<text>         → OK | ERR ...
  *   CLICK_IN_WIN <title>|<button>         → OK | ERR ...
  *   JTREE_SELECT_PATH <title>|<p1>/<p2>/..→ OK selected=<path> | ERR ...
+ *   JLIST_SELECT <title>|<item>          → OK selected=<item> | ERR ...
  *   JCHECK <title>|<name>|<true|false>    → OK unchanged=<v> | OK changed=<v> | ERR ...
  *   SETTEXT_BY_LABEL <title>|<label>|<v>  → OK set label=<label> value=<v> | ERR ...
  *   SETTEXT_LOGIN_USER <text>             → OK | ERR ...
@@ -225,6 +229,18 @@ public class GatewayInputAgent {
                 // Configuration dialog's ConfigurationTree
                 // (e.g. "API/Settings").
                 return doJTreeSelectPath(rest);
+            }
+            case "JLIST_SELECT": {
+                // Select an item by text in the first JList inside the
+                // first showing window whose title contains <title_substr>.
+                // Protocol: JLIST_SELECT <title_substr>|<item_text>
+                // Used to pick the 2FA device (e.g. "Mobile Authenticator
+                // app") in the Second Factor Authentication dialog's
+                // device list on multi-method accounts — the controller's
+                // AT-SPI view can't drive JList, but the in-JVM agent can
+                // (mirrors IBC's SecondFactorDevice handling of the same
+                // dialog).
+                return doJListSelect(rest);
             }
             case "JCHECK": {
                 // Set a toggle-style button (JCheckBox, JRadioButton,
@@ -407,8 +423,19 @@ public class GatewayInputAgent {
                 break;
             }
         }
-        if (field == null && !fields.isEmpty()) {
-            field = fields.get(0);  // fallback to first regardless
+        if (field == null) {
+            // Fall back to the first real input field (JTextField /
+            // JPasswordField) even if it reports non-editable, but NEVER a
+            // JTextArea — those are dialog headings/body text (e.g. the 2FA
+            // device-selector's "Select second factor device" heading), and
+            // typing into one silently corrupts the dialog while appearing
+            // to succeed (SETTEXT returned OK, code landed in a heading).
+            for (JTextComponent f : fields) {
+                if (f instanceof JTextField) {
+                    field = f;
+                    break;
+                }
+            }
         }
         if (field == null) {
             return "ERR not_found text_component_in_window=" + titleSubstr;
@@ -531,6 +558,52 @@ public class GatewayInputAgent {
             tree.scrollPathToVisible(targetPath);
         });
         return "OK selected=" + pathStr;
+    }
+
+    private static String doJListSelect(String rest) throws Exception {
+        // Protocol: JLIST_SELECT <title_substr>|<item_text>
+        int pipe = rest.indexOf('|');
+        if (pipe < 0) {
+            return "ERR jlist_select_missing_pipe";
+        }
+        String titleSubstr = rest.substring(0, pipe);
+        String itemText = rest.substring(pipe + 1);
+
+        Window target = findWindowByTitleSubstring(titleSubstr);
+        if (target == null) {
+            return "ERR not_found window_title_substring=" + titleSubstr;
+        }
+
+        // First JList inside this window — the 2FA device selector is
+        // the only list in the Second Factor Authentication dialog.
+        // JList is generic; collect() infers the raw type here, which
+        // is fine for iterating the model.
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        List<JList> lists = collect(target, JList.class);
+        if (lists.isEmpty()) {
+            return "ERR no_jlist_in_window=" + titleSubstr;
+        }
+        final JList<?> list = lists.get(0);
+        final ListModel<?> model = list.getModel();
+
+        int found = -1;
+        for (int i = 0; i < model.getSize(); i++) {
+            Object entry = model.getElementAt(i);
+            String entryStr = entry == null ? "" : entry.toString().trim();
+            if (entryStr.equals(itemText)) {
+                found = i;
+                break;
+            }
+        }
+        if (found < 0) {
+            return "ERR jlist_item_not_found want=" + itemText;
+        }
+        final int idx = found;
+        SwingUtilities.invokeAndWait(() -> {
+            list.setSelectedIndex(idx);
+            list.ensureIndexIsVisible(idx);
+        });
+        return "OK selected=" + itemText;
     }
 
     private static String doJCheck(String rest) throws Exception {

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -559,6 +559,28 @@ def agent_click_in_window(title_substring, button_text):
     return False
 
 
+def agent_jlist_select(title_substring, item_text):
+    """Ask the agent to select an item by text in the first JList of a
+    window whose title contains the given substring.
+
+    Used to pick the 2FA device (e.g. \"Mobile Authenticator app\") in
+    the Second Factor Authentication dialog's device list on
+    multi-method accounts (issue #7): Gateway pre-selects one method
+    there and the controller's AT-SPI view can't drive a JList, but the
+    in-JVM agent can — mirroring IBC's SecondFactorDevice handling of
+    the same dialog.
+    """
+    try:
+        resp = _agent_request(f"JLIST_SELECT {title_substring}|{item_text}")
+    except Exception as e:
+        log.error(f"agent JLIST_SELECT {title_substring!r}: {type(e).__name__}: {e}")
+        return False
+    if resp.startswith("OK"):
+        return True
+    log.error(f"agent JLIST_SELECT {title_substring!r}: {resp}")
+    return False
+
+
 def agent_close_window(title_substring):
     """v0.5.6: Post a WINDOW_CLOSING event to the first showing window
     whose title contains ``title_substring``. Returns True if the event
@@ -1704,6 +1726,65 @@ def handle_2fa(app):
             else:
                 # TOTP mode: type the code and click OK
                 log.info(f"2FA dialog detected: {two_fa_window}")
+                # Multi-method accounts: Gateway's 2FA dialog may first
+                # show a "Select second factor device" list (pre-selected
+                # to IB Key when multiple methods are enabled) instead of
+                # going straight to a code-entry prompt. If the selector
+                # is present, pick the device named by TWOFA_DEVICE
+                # (default "Mobile Authenticator app" in TOTP mode) and
+                # click OK; the dialog then switches to the code-entry
+                # prompt and the flow below types the TOTP. Without this
+                # step the code would be entered into a dialog still
+                # expecting IB Key approval (issue #7 — the list is
+                # drivable in-JVM via JLIST_SELECT even though AT-SPI
+                # can't see it; same dialog IBC's SecondFactorDevice
+                # handles).
+                # NOTE: the "Select second factor device" heading is a
+                # JTextArea, which agent_labels() (JLabel-only) misses —
+                # IBC's handler finds it via findTextArea. Use the full
+                # component-tree dump instead (covers JLabel,
+                # JTextComponent incl. JTextArea, and AbstractButton).
+                window_dump = agent_window(TWOFA_WINDOW_SUBSTR)
+                selector_present = "Select second factor device" in (window_dump or "")
+                if selector_present:
+                    log.info("2FA dialog shows device selector — selecting "
+                             f"{twofa_device!r} before TOTP entry")
+                    if not agent_jlist_select(TWOFA_WINDOW_SUBSTR, twofa_device):
+                        log.error("JLIST_SELECT on 2FA device selector failed")
+                        log.error(
+                            f"ALERT_2FA_FAILED mode={TRADING_MODE} "
+                            "reason=\"JLIST_SELECT on 2FA device selector failed\"")
+                        return False
+                    if not agent_click_in_window(TWOFA_WINDOW_SUBSTR, "OK"):
+                        log.error("CLICK_IN_WIN OK on 2FA device selector failed")
+                        log.error(
+                            f"ALERT_2FA_FAILED mode={TRADING_MODE} "
+                            "reason=\"CLICK_IN_WIN OK on 2FA device selector failed\"")
+                        return False
+                    # Give the dialog a beat to switch to the code-entry
+                    # prompt before the method-prompt check below.
+                    # After device selection Gateway re-authenticates
+                    # with the chosen method: the code-entry dialog appears
+                    # only after a network round-trip (observed seconds,
+                    # not ms). Poll for it; log window titles only when
+                    # they change (mirrors the 2FA wait loop).
+                    code_dialog_ready = False
+                    last_poll_windows = None
+                    for _poll in range(15):
+                        time.sleep(1.0)
+                        ws = agent_windows()
+                        titles = [t for _, t, _ in ws]
+                        if titles != last_poll_windows:
+                            log.info(f"Post-select windows: {titles}")
+                            last_poll_windows = titles
+                        if any(("second factor" in t.lower()
+                                or "authenticator" in t.lower()
+                                or "enter" in t.lower()) for t in titles):
+                            code_dialog_ready = True
+                            break
+                    if not code_dialog_ready:
+                        log.warning("No 2FA code-entry dialog detected within "
+                                    "15s after device selection")
                 # v0.7.0 (issue #7): on a multi-method account Gateway's
                 # dialog is pre-defaulted to one method and shows an
                 # "Enter <method> code" prompt. Only type our TOTP if the
@@ -1749,16 +1830,31 @@ def handle_2fa(app):
                              f"{twofa_device!r}")
                 code = generate_totp(TOTP_SECRET)
                 log.info(f"Typing TOTP code into the 2FA dialog")
-                if not agent_settext_in_window(TWOFA_WINDOW_SUBSTR, code):
-                    log.error("SETTEXT_IN_WIN on 2FA dialog failed")
+                # The code-entry dialog's title may differ from the
+                # device-selector dialog's ("Second Factor ..."); try
+                # candidate substrings in order.
+                settext_ok = False
+                for _substr in ("Second Factor", "Authenticator", "Authentication"):
+                    if agent_settext_in_window(_substr, code):
+                        settext_ok = True
+                        break
+                if not settext_ok:
+                    log.error("SETTEXT_IN_WIN on 2FA dialog failed "
+                              "(tried Second Factor/Authenticator/Authentication)")
                     log.error(
                         f"ALERT_2FA_FAILED mode={TRADING_MODE} "
                         "reason=\"agent SETTEXT_IN_WIN on 2FA dialog failed\"")
                     return False
                 time.sleep(0.5)
                 log.info("Clicking OK in 2FA dialog")
-                if not agent_click_in_window(TWOFA_WINDOW_SUBSTR, "OK"):
-                    log.error("CLICK_IN_WIN OK on 2FA dialog failed")
+                click_ok = False
+                for _substr in ("Second Factor", "Authenticator", "Authentication"):
+                    if agent_click_in_window(_substr, "OK"):
+                        click_ok = True
+                        break
+                if not click_ok:
+                    log.error("CLICK_IN_WIN OK on 2FA dialog failed "
+                              "(tried Second Factor/Authenticator/Authentication)")
                     log.error(
                         f"ALERT_2FA_FAILED mode={TRADING_MODE} "
                         "reason=\"agent CLICK_IN_WIN OK on 2FA dialog failed\"")


### PR DESCRIPTION
Closes #7 (partial): multi-method 2FA dialog is a device selector and is now detected + driven mechanically; the switch is rejected server-side on 10.45.1c (see #20), so on current versions the net effect is accurate failure detection and a SETTEXT fallback bugfix.

## Changes

**agent/GatewayInputAgent.java**
- New `JLIST_SELECT <title>|<item>` command (protocol v0.2 → v0.3): select an item by text in the first JList of a window.
- `SETTEXT_IN_WIN` fallback: only consider JTextField/JPasswordField, never JTextArea headings — the old catch-all fallback typed the TOTP into the `Select second factor device` heading (silently, returning OK).

**gateway_controller.py**
- `agent_jlist_select()` helper.
- `handle_2fa` TOTP branch: detect the device selector via component-tree dump (the heading is a JTextArea, invisible to `agent_labels()`), select `TWOFA_DEVICE`, click OK, poll up to 15s for the code-entry dialog. If the switch is rejected → clear `ALERT_2FA_FAILED` (previously: `2FA handled successfully` then a failed login).
- SETTEXT/CLICK on the 2FA dialog try multiple title substrings since the code-entry dialog's title may differ from the selector's.

## Test plan (hand-written, per CONTRIBUTING)

1. `make clean && make` passes (JDK 17). ✅ verified locally.
2. Single-method account: selector absent → flow unchanged (no regression).
3. Multi-method 10.45.1c: selector detected → JLIST_SELECT OK → OK clicked → poll → no code dialog → ALERT_2FA_FAILED (previously silent wrong-typing). ✅ verified on a real account (3 attempts; see issue #20 for logs).
4. SETTEXT_IN_WIN with only JTextArea headings → ERR (was: OK + text in heading).

Full findings, component-tree dump and screenshot description in issue #20.