### PR TITLE
fix: adopt Gateway's self-restarted JVM instead of racing it (fixes #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,11 +158,28 @@ and the project follows [Semantic Versioning](https://semver.org/).
   directory the relative log path resolves against, and a deployment
   using `AUTO_LOGOFF_TIME` rather than `AUTO_RESTART_TIME` has never
   written a `restarter.log` — the unchanged-behaviour case.
-- Gateway's real auto-restart itself is still not reproduced here — no
-  maintainer deployment sets `AUTO_RESTART_TIME`, and the reporter
-  reports their own equivalent patch working on the first night in
-  production (issue #23). `monitor_loop`'s adopted-exit branch is
-  exercised only indirectly, through `_recover_jvm_or_escalate`.
+- **Driven against a real Gateway and the real restarter**
+  (`tests/integration/gateway_autorestart_drill.py`, 17/17 on Gateway
+  10.45.1g, 2026-09-07). The drill launches Gateway through its real
+  install4j launcher with the real agent, invokes
+  `.install4j/restarter` with the environment Gateway itself carries,
+  and runs the recovery path against whatever comes up. Observed: the
+  restarter inherits `INSTALL4J_ADD_VM_PARAMS` and loads the agent; it
+  holds the agent socket for about a second between the old JVM dying
+  and the replacement binding it (the window the restarter
+  discrimination exists for, now observed rather than hypothesised);
+  and the controller adopts the replacement — a JVM it never spawned —
+  in 0.5 s, with `do_restart_in_place` never called and exactly one
+  Gateway left running. No credentials are used and nothing
+  authenticates, so no session slot is touched. Not part of `make
+  test`; it needs a Gateway install, an X display and ~2 minutes.
+- One fact the drill stands in for: with no credentials the replacement
+  Gateway sits at its login dialog and never opens its API port, so
+  "the session is preserved across the restart" is asserted rather than
+  observed. That is IBKR behaviour the controller neither causes nor
+  changes, documented by IBC and reported in production by the issue
+  reporter. `monitor_loop`'s adopted-exit branch is exercised only
+  indirectly, through `_recover_jvm_or_escalate`.
 
 ## [0.8.1] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,21 @@ and the project follows [Semantic Versioning](https://semver.org/).
   with no auto-restart time ran 13 days clean).
   - On a JVM exit the controller now checks the mtime of install4j's
     `restarter.log` next to the launcher. That file being freshly
-    written is the restarter's own statement that it ran — the only
-    trigger used. Not a wall-clock comparison against
-    `AUTO_RESTART_TIME`, which would have to guess which timezone
-    Gateway's Lock-and-Exit field is in and would fire on any code-0
-    exit that landed in the window.
+    written is the restarter's own statement that it ran. Not a
+    wall-clock comparison against `AUTO_RESTART_TIME`, which would have
+    to guess which timezone Gateway's Lock-and-Exit field is in and
+    would fire on any code-0 exit that landed in the window.
+  - **`restarter.log` is not guaranteed to exist.** Verified against a
+    real install on 2026-09-06: Gateway 10.45.1g ships
+    `.install4j/restarter` and runs it, but no `restarter.log` is
+    written, while the reporter's 10.45.1j box writes one with install4j
+    action-log content. So after a clean exit with no usable log the
+    controller asks a more direct question for up to
+    `AUTO_RESTART_PROBE_SECONDS` (default 15): is a live Gateway JVM
+    that we never spawned already answering on our agent socket? Only a
+    running JVM can answer it, and launching a second instance in that
+    state is exactly this bug. `ALERT_AUTO_RESTART` reports which signal
+    fired via `detected_via=restarter_log|agent_socket`.
   - If it was just written: no relaunch. The controller waits for the
     instance install4j is bringing up (it inherits
     `INSTALL4J_ADD_VM_PARAMS` through the restarter, so its agent binds
@@ -68,8 +78,25 @@ and the project follows [Semantic Versioning](https://semver.org/).
   `failed_api_timeout` (WARNING), one line per adoption attempt. See
   [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
 - **`AUTO_RESTART_ADOPT`** (default `yes`) — set to `no` to restore the
-  always-relaunch behaviour, and **`AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`**
-  (default `90`) — how long to wait for the self-restarted JVM's agent.
+  always-relaunch behaviour; **`AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`**
+  (default `90`) — how long to wait for the self-restarted JVM's agent;
+  and **`AUTO_RESTART_PROBE_SECONDS`** (default `15`) — how long to
+  probe the agent socket when no `restarter.log` was written. The probe
+  plus a 5 s late-log grace is the only added latency, and only on clean
+  exits.
+
+### Fixed (found by that validation)
+
+- **A dead adopted JVM could look alive indefinitely.** `_AdoptedProcess`
+  inferred liveness from `os.kill(pid, 0)` plus `/proc`. Where `/proc`
+  is absent, or the exit is left unreaped, a dead JVM still answered
+  "alive", so teardown spent its full `JVM_TEARDOWN_GRACE_SECONDS`
+  SIGTERM wait and then a SIGKILL on a process that had already exited —
+  turning a 6 s failure path into a 40 s one and emitting a spurious
+  `ALERT_JVM_UNCLEAN_SHUTDOWN`. Liveness now attempts a `WNOHANG` reap
+  first (a no-op in production, where the JVM is install4j's child, not
+  ours) before the signal and `/proc` checks. Caught by the end-to-end
+  tests below, not by the mocked unit tests.
 
 ### Validation
 
@@ -90,12 +117,27 @@ and the project follows [Semantic Versioning](https://semver.org/).
   restart; half-adopted teardown; exception fall-through; env
   kill-switch; alive-JVM skip; unobservable exit status treated like
   0 by the guard), and the `attempt_reauth` / `_redrive_login` split.
-- The adoption path is harness-validated only in this repo — no
-  maintainer deployment runs `AUTO_RESTART_TIME`. The reporter reports
-  their own equivalent patch working on the first night in production
-  (issue #23). Confirmation from a real `AUTO_RESTART_TIME` deployment
-  is invited. `monitor_loop`'s adopted-exit branch is exercised only
-  indirectly, through `_recover_jvm_or_escalate`.
+- **End-to-end coverage with real processes**
+  (`TestAutoRestartAdoptionEndToEnd`): a stand-in Gateway JVM binds the
+  agent's Unix socket the way the real agent does and optionally opens
+  an API port, so adoption runs against real PIDs, real signals, a real
+  socket and the real `_AdoptedProcess` — only Gateway itself is
+  substituted. Covers the self-restart being adopted with no second
+  launch, adoption via the socket probe when no `restarter.log` is
+  written, a genuine crash still falling through to the relaunch inside
+  a bounded detection budget, a stale log being ignored, an adopted JVM
+  dying before its API port, and the same restart not being adopted
+  twice.
+- Path assumptions checked against a real install (Gateway 10.45.1g in
+  the maintainer's running container): `.install4j/restarter` sits where
+  the code looks for it, and a deployment using `AUTO_LOGOFF_TIME`
+  rather than `AUTO_RESTART_TIME` has never written a `restarter.log` —
+  the unchanged-behaviour case.
+- Gateway's real auto-restart itself is still not reproduced here — no
+  maintainer deployment sets `AUTO_RESTART_TIME`, and the reporter
+  reports their own equivalent patch working on the first night in
+  production (issue #23). `monitor_loop`'s adopted-exit branch is
+  exercised only indirectly, through `_recover_jvm_or_escalate`.
 
 ## [0.8.1] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,17 +28,32 @@ and the project follows [Semantic Versioning](https://semver.org/).
     wall-clock comparison against `AUTO_RESTART_TIME`, which would have
     to guess which timezone Gateway's Lock-and-Exit field is in and
     would fire on any code-0 exit that landed in the window.
-  - **`restarter.log` is not guaranteed to exist.** Verified against a
-    real install on 2026-09-06: Gateway 10.45.1g ships
-    `.install4j/restarter` and runs it, but no `restarter.log` is
-    written, while the reporter's 10.45.1j box writes one with install4j
-    action-log content. So after a clean exit with no usable log the
-    controller asks a more direct question for up to
-    `AUTO_RESTART_PROBE_SECONDS` (default 15): is a live Gateway JVM
-    that we never spawned already answering on our agent socket? Only a
-    running JVM can answer it, and launching a second instance in that
-    state is exactly this bug. `ALERT_AUTO_RESTART` reports which signal
-    fired via `detected_via=restarter_log|agent_socket`.
+  - **`restarter.log`'s location depends on the working directory.**
+    The restarter writes it via `-Dinstall4j.alternativeLogfile=`
+    `./.install4j/restarter.log` — a *relative* path, resolved against
+    the working directory it inherits from Gateway's JVM. Gateway runs
+    with its install directory as the working directory (verified in a
+    running container), so in a real auto-restart the log does land
+    exactly where this code looks for it. But nothing guarantees that
+    for every install, so the log is the primary signal, not the only
+    one: after a clean exit with no usable log the controller asks a
+    more direct question for up to `AUTO_RESTART_PROBE_SECONDS`
+    (default 15) — is a live Gateway JVM we never spawned already
+    answering on our agent socket? Only a running JVM can answer it,
+    and launching a second instance in that state is exactly this bug.
+  - **The restarter is itself a JVM, and it loads our agent.** Verified
+    2026-09-06 by running the real `.install4j/restarter` binary: it
+    inherits `INSTALL4J_ADD_VM_PARAMS` from the JVM that spawned it, so
+    it loads `-javaagent:gateway-input-agent.jar`, binds the agent
+    socket, and answers `GET_PID` with *its own* PID for the couple of
+    seconds it lives. Adoption now identifies it by the
+    `-Dinstall4j.alternativeLogfile` flag that Gateway's own JVM does
+    not carry (`i4jruntime.jar` is not a discriminator — Gateway's
+    cmdline contains it too) and waits for the Gateway JVM it launches
+    instead of adopting a process that is about to exit. Seeing the
+    restarter on the socket is itself conclusive evidence of a
+    self-restart. `ALERT_AUTO_RESTART` reports which signal fired via
+    `detected_via=restarter_log|agent_socket|install4j_restarter`.
   - If it was just written: no relaunch. The controller waits for the
     instance install4j is bringing up (it inherits
     `INSTALL4J_ADD_VM_PARAMS` through the restarter, so its agent binds
@@ -128,11 +143,21 @@ and the project follows [Semantic Versioning](https://semver.org/).
   a bounded detection budget, a stale log being ignored, an adopted JVM
   dying before its API port, and the same restart not being adopted
   twice.
+- **The load-bearing assumption is now verified rather than assumed.**
+  The fix rests on the restarted Gateway inheriting
+  `INSTALL4J_ADD_VM_PARAMS`, hence loading the agent and reporting a new
+  PID on the same socket. Running the real `.install4j/restarter` binary
+  in a container off the release image confirms the inheritance
+  directly: given a deliberately bogus `-javaagent` value the
+  restarter's own VM refused to start, and given the real agent jar it
+  logged `[gateway-input-agent] listening on <socket>` and answered
+  `GET_PID`. The environment does propagate through the restarter chain.
 - Path assumptions checked against a real install (Gateway 10.45.1g in
   the maintainer's running container): `.install4j/restarter` sits where
-  the code looks for it, and a deployment using `AUTO_LOGOFF_TIME`
-  rather than `AUTO_RESTART_TIME` has never written a `restarter.log` —
-  the unchanged-behaviour case.
+  the code looks for it, Gateway's working directory is the install
+  directory the relative log path resolves against, and a deployment
+  using `AUTO_LOGOFF_TIME` rather than `AUTO_RESTART_TIME` has never
+  written a `restarter.log` — the unchanged-behaviour case.
 - Gateway's real auto-restart itself is still not reproduced here — no
   maintainer deployment sets `AUTO_RESTART_TIME`, and the reporter
   reports their own equivalent patch working on the first night in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,99 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Gateway's own daily auto-restart no longer races the controller
+  into a cold login (issue #23).** With `AUTO_RESTART_TIME` set,
+  Gateway restarts *itself* at that time: the JVM spawns install4j's
+  `.install4j/restarter`, which shuts the calling launcher down and
+  re-executes it, and the replacement re-uses the session credentials
+  — no login, no second factor. `monitor_loop` saw that code-0 exit as
+  a crash and `do_restart_in_place` launched a **second** Gateway ~2 s
+  before install4j launched its own: two instances on one display and
+  one settings dir, the agent drove the wrong window, login failed,
+  the controller halted, and the container's restart policy brought
+  it back as a cold login — a fresh IB Key push every night (the
+  reporter measured 23 container restarts and 1-2 h without a session
+  per night over five days; an otherwise identical paper container
+  with no auto-restart time ran 13 days clean).
+  - On a JVM exit the controller now checks the mtime of install4j's
+    `restarter.log` next to the launcher. That file being freshly
+    written is the restarter's own statement that it ran — the only
+    trigger used. Not a wall-clock comparison against
+    `AUTO_RESTART_TIME`, which would have to guess which timezone
+    Gateway's Lock-and-Exit field is in and would fire on any code-0
+    exit that landed in the window.
+  - If it was just written: no relaunch. The controller waits for the
+    instance install4j is bringing up (it inherits
+    `INSTALL4J_ADD_VM_PARAMS` through the restarter, so its agent binds
+    the same socket and reports its PID), adopts it as `GATEWAY_PROC`
+    through a Popen-shaped stand-in (`os.kill(pid, 0)` liveness,
+    zombie- and PID-reuse-aware via `/proc`), and resumes monitoring
+    as soon as the API port is open. The reporter's equivalent patch
+    in their production: three seconds, no login dialog, no push, no
+    container restart.
+  - If the session was **not** preserved and a login dialog appears
+    instead (e.g. IBKR's weekly full re-authentication), the existing
+    re-auth pipeline is driven on the adopted JVM.
+  - If the first JVM to answer dies before its API port opens, the
+    controller looks once more for another instance from the restarter
+    chain before giving up, and never re-offers a PID it already found
+    dead.
+  - Fail-safe: no `restarter.log`, a stale or far-future one, one that
+    hasn't changed since the last adoption attempt (so a JVM that dies
+    inside the 120 s freshness window is treated as a real failure, not
+    another self-restart), no new PID within
+    `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS` (default 90), or an API port
+    that never opens — each falls through to the previous behaviour
+    (`do_restart_in_place`), tearing down a half-adopted instance first
+    so it isn't left running alongside the relaunch.
+  - Adoption is ordered ahead of the v0.5.10 maintenance-window guard:
+    `AUTO_RESTART_TIME` commonly sits inside that window, and an
+    8-minute sleep is pointless when there is nothing to re-auth. The
+    guard still applies on the branch that *does* re-auth (session not
+    preserved).
+  - Reported, diagnosed, and prototyped in production by
+    @maciejlaska.
+
+### Added
+
+- **`ALERT_AUTO_RESTART` grep-contract token** — `status=adopted`
+  (INFO) or `failed_no_agent` / `failed_jvm_exited` / `failed_login` /
+  `failed_api_timeout` (WARNING), one line per adoption attempt. See
+  [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
+- **`AUTO_RESTART_ADOPT`** (default `yes`) — set to `no` to restore the
+  always-relaunch behaviour, and **`AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`**
+  (default `90`) — how long to wait for the self-restarted JVM's agent.
+
+### Validation
+
+- New unit coverage: `_install4j_restarter_age` (fresh / stale /
+  missing / future-dated log, unknown launcher, discovery fallback),
+  `_AdoptedProcess` against real child processes (live, terminated,
+  killed, gone-before-adoption, wait timeout; unreaped-zombie and
+  `/proc` parsing on Linux), `_adopt_self_restarted_gateway`
+  orchestration (not a self-restart, grace re-check for a late
+  restarter write, no grace on non-zero exits, no new agent, adopted
+  via API port, login dialog re-driven, the maintenance guard applying
+  to that re-login, login failure and API timeout leaving the adopted
+  instance in place for teardown, adopted JVM dying, retry onto a
+  second candidate from the restarter chain, the same restarter.log
+  not being adopted twice, disclaimer dismissal while waiting),
+  `_recover_jvm_or_escalate`
+  ordering (adoption before the maintenance guard and the fast
+  restart; half-adopted teardown; exception fall-through; env
+  kill-switch; alive-JVM skip; unobservable exit status treated like
+  0 by the guard), and the `attempt_reauth` / `_redrive_login` split.
+- The adoption path is harness-validated only in this repo — no
+  maintainer deployment runs `AUTO_RESTART_TIME`. The reporter reports
+  their own equivalent patch working on the first night in production
+  (issue #23). Confirmation from a real `AUTO_RESTART_TIME` deployment
+  is invited. `monitor_loop`'s adopted-exit branch is exercised only
+  indirectly, through `_recover_jvm_or_escalate`.
+
 ## [0.8.1] - 2026-08-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ LICENSE                   ← MIT
 
 ## Testing
 
-Two layers:
+Three layers:
 
 **Unit suite** — `tests/`, stdlib `unittest` only, no pip installs:
 
@@ -98,6 +98,35 @@ the `agent_*` socket wrappers with `unittest.mock.patch.object` — see
 `tests/test_pure_logic.py` for the house patterns. New logic should
 follow the same shape: keep decisions in small pure helpers, test them
 directly, and mock the agent boundary for flow tests.
+
+**Integration drills** — `tests/integration/`, run by hand against a
+real Gateway install in a **throwaway container**, never against one
+holding a live session. They use no credentials and never authenticate,
+so no IBKR session slot is touched:
+
+```
+docker run -d --name ibg-drill --entrypoint sleep \
+  -v "$PWD":/repo:ro ghcr.io/<owner>/ibg-controller:<tag> 3600
+docker exec -d ibg-drill sh -c 'Xvfb :1 -screen 0 1024x768x24 &'
+docker exec -e DISPLAY=:1 -e TRADING_MODE=paper \
+  -e TWS_SETTINGS_PATH=/home/ibgateway/Jts_paper \
+  -e GATEWAY_INPUT_AGENT_SOCKET=/tmp/gateway-input-paper.sock \
+  ibg-drill python3 /repo/tests/integration/gateway_autorestart_drill.py
+```
+
+`gateway_autorestart_drill.py` is the model: it exercises Gateway's own
+daily restart (issue #23) by launching the real JVM through the real
+install4j launcher and invoking the real `.install4j/restarter`. Reach
+for this layer when a change depends on how Gateway or install4j
+actually behaves as a *process* — launcher chains, PID identity,
+environment inheritance, the agent socket handoff. Mocked tests cannot
+falsify assumptions in that territory; this drill has already caught
+two defects that the unit suite passed clean.
+
+Each check prints `[PASS]`/`[FAIL]` with a one-line reason, and the
+docstring records what was observed and when. Anything the drill has to
+stand in for (an API port that only opens after a real login, say) must
+be called out there rather than quietly patched.
 
 **Live validation** — end-to-end truth (real dialog wording, window
 timing, IBKR server-side behavior) requires a real IB account +

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ real product.
 | `TWS_MASTER_CLIENT_ID` | Master API client ID |
 | `READ_ONLY_API` | `yes`/`no` |
 | `AUTO_LOGOFF_TIME` / `AUTO_RESTART_TIME` | `HH:MM` / `HH:MM AM/PM`. Gateway shows one field or the other depending on account state; set both vars and the controller handles whichever is displayed. |
+| `AUTO_RESTART_ADOPT` | Default `yes`: when Gateway restarts itself at `AUTO_RESTART_TIME`, adopt the new JVM instead of launching a second one. Gateway normally carries the session across, so no login and no 2FA; when it doesn't, the controller re-drives login on the adopted JVM. `no` restores always-relaunch. Wait budget: `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS` (90). |
 
 ### Command server
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -272,7 +272,14 @@ Why each was added:
     transparently swap them mid-loop). Checks JVM exit every iteration,
     heartbeats the API port every 30s, triggers `attempt_reauth()`
     after three consecutive port-closed heartbeats + a visible login
-    dialog.
+    dialog. On JVM exit, `_recover_jvm_or_escalate()` first asks
+    whether install4j's `restarter.log` (next to the launcher) was just
+    written — Gateway's own `AUTO_RESTART_TIME` restart (issue #23). If
+    so it adopts the JVM install4j brings up (`_AdoptedProcess`, a
+    Popen-shaped stand-in for a process the controller didn't spawn;
+    the new JVM inherits `INSTALL4J_ADD_VM_PARAMS` and so binds the
+    same agent socket) instead of relaunching; otherwise the v0.5.10
+    maintenance-window guard and `do_restart_in_place()` follow.
 
 ### 6. Dual mode (`TRADING_MODE=both`) dispatch (v0.2)
 

--- a/docs/DISCONNECT_RECOVERY.md
+++ b/docs/DISCONNECT_RECOVERY.md
@@ -412,10 +412,19 @@ brought it back as a cold login — with an IB Key push every night and
 
 ### Recovery
 
-Automatic. The controller only trusts install4j's own evidence — the
-mtime of `restarter.log` next to the launcher — never the wall-clock
-versus `AUTO_RESTART_TIME` (whose timezone it cannot know). Every
-failure inside the adoption path (no `restarter.log`, a stale one, no
+Automatic, and never on a wall-clock comparison against
+`AUTO_RESTART_TIME` (whose timezone the controller cannot know). Two
+signals, in order:
+
+1. **install4j's own evidence** — the mtime of `restarter.log` next to
+   the launcher.
+2. **A live JVM the controller didn't spawn**, answering on the agent
+   socket within `AUTO_RESTART_PROBE_SECONDS` of a clean exit. Not
+   every install4j build writes `restarter.log` (Gateway 10.45.1g's
+   restarter writes none), so this fallback keeps the fix working where
+   the log never appears.
+
+Every failure inside the adoption path (neither signal, a stale log, no
 new JVM within `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`, an API port that
 never opens) falls through to the previous behaviour, i.e. the fast
 in-place relaunch, after tearing down any half-adopted instance.

--- a/docs/DISCONNECT_RECOVERY.md
+++ b/docs/DISCONNECT_RECOVERY.md
@@ -358,6 +358,9 @@ the controller recovers by relaunching.
 
 The controller's `_recover_jvm_or_escalate` helper (v0.4.7+) handles
 this automatically:
+0. If install4j's `restarter.log` was just written, this was Gateway's
+   own auto-restart, not a crash — adopt the new instance instead of
+   relaunching (see the next scenario).
 1. Fast in-place restart (`do_restart_in_place`) — no cool-down.
 2. If the fast path fails, fall through to
    `_escalate_to_jvm_restart` (v0.4.6 silent cool-down).
@@ -365,6 +368,63 @@ this automatically:
    scenario above.
 
 Operator action is only needed if the exhausted token fires.
+
+---
+
+## Scenario: Gateway's own daily auto-restart (`AUTO_RESTART_TIME`)
+
+**TL;DR**: with an auto-restart time configured, Gateway restarts
+*itself* every day and keeps the session — no login, no second
+factor. The controller adopts the new JVM instead of launching its
+own. No operator action needed; `ALERT_AUTO_RESTART status=adopted`
+once per night per mode is the expected signal.
+
+### Symptoms
+
+- Monitor logs show, at the configured time:
+  ```
+  Gateway JVM exited with code 0
+  AUTORESTART: install4j restarter ran 0s ago (/home/ibgateway/Jts/ibgateway/10.45.1j/.install4j/restarter.log)
+  AUTORESTART: Gateway is restarting itself — NOT launching a second instance (old pid=27); waiting up to 90s for the new JVM's agent on /tmp/gateway-input-live.sock
+  AUTORESTART: adopted Gateway pid=5020 (was 27) after 0s
+  ALERT_AUTO_RESTART mode=live status=adopted old_pid=27 new_pid=5020 elapsed_seconds=3 reason="API port 4001 open — session preserved across Gateway's auto-restart, no login and no second factor required"
+  ```
+- `/health` flips to `unhealthy` for a few seconds (`jvm_alive:
+  false`, then a new `jvm_pid`) and back to `healthy`.
+- On the night of IBKR's weekly full re-authentication the session is
+  *not* preserved: a login dialog appears on the self-restarted JVM
+  and the controller drives the normal re-auth pipeline on it
+  (`status=adopted` with `reason="session not preserved; ..."`, and a
+  second factor is required as usual).
+
+### Root cause
+
+Gateway's Lock-and-Exit "Set Auto Restart Time" makes the JVM spawn
+install4j's `.install4j/restarter`, which shuts the calling launcher
+down and re-executes it. The replacement re-uses the session
+credentials. Before the issue #23 fix the controller treated the
+code-0 exit as a crash and launched a **second** Gateway about two
+seconds before install4j launched its own: two instances on one X
+display and one settings dir, the agent drove the wrong window,
+login failed, the controller halted, and the container restart policy
+brought it back as a cold login — with an IB Key push every night and
+1-2 h without a usable session.
+
+### Recovery
+
+Automatic. The controller only trusts install4j's own evidence — the
+mtime of `restarter.log` next to the launcher — never the wall-clock
+versus `AUTO_RESTART_TIME` (whose timezone it cannot know). Every
+failure inside the adoption path (no `restarter.log`, a stale one, no
+new JVM within `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`, an API port that
+never opens) falls through to the previous behaviour, i.e. the fast
+in-place relaunch, after tearing down any half-adopted instance.
+
+If the adopted path misbehaves in your deployment, set
+`AUTO_RESTART_ADOPT=no` to restore always-relaunch (and expect the
+nightly cold login back). Diagnostics: the `ALERT_AUTO_RESTART`
+`status=` value, the `AUTORESTART:` progress lines, and install4j's
+`restarter.log` itself.
 
 ---
 
@@ -446,6 +506,7 @@ to outlast the drain in your region.
 |---|---|---|---|
 | Short API port flap | ✅ next monitor cycle | ❌ not needed | `/health` flips briefly |
 | Gateway JVM crash | ✅ in-place restart | ❌ not needed | `jvm_alive: false` in `/health` |
+| Gateway's own daily auto-restart | ✅ adopts the new JVM | ❌ not needed | `ALERT_AUTO_RESTART status=adopted` at `AUTO_RESTART_TIME` |
 | IBKR daily maintenance window | ✅ 8-min delay + re-auth | ❌ not needed | `ALERT_IBKR_MAINTENANCE_RECOVERY` at ~23:45 ET |
 | CCP rate limiter tripped (genuine) | ✅ silent cool-down | ❌ not needed (wait up to 20 min) | `ccp_backoff_seconds > 0` |
 | **CCP lockout — concurrent/stranded session** | ❌ cannot auto-recover | ✅ log into IBKR Mobile (force-kicks TWS slot; web Portal does NOT) | `ALERT_CCP_PERSISTENT` + `ccp_lockout_streak >= 3` |

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -63,7 +63,7 @@ for Kubernetes-style readiness where "process up" is the signal.
 | `mode` | `"live"` \| `"paper"` | The `TRADING_MODE` this controller is driving. |
 | `state` | string | Controller state machine position. One of `INIT`, `LAUNCHING`, `AGENT_WAIT`, `APP_DISCOVERY`, `LOGIN`, `POST_LOGIN`, `TWO_FA`, `DISCLAIMERS`, `API_WAIT`, `CONFIG`, `COMMAND_SERVER`, `READY`, `MONITORING`. |
 | `jvm_pid` | int \| null | OS PID of the Gateway JVM. `null` before agent discovery completes. |
-| `jvm_alive` | bool | `true` iff the controller's `subprocess.Popen` handle reports the JVM hasn't exited. |
+| `jvm_alive` | bool | `true` iff the controller's handle on the Gateway JVM reports it hasn't exited. Normally a `subprocess.Popen`; after Gateway's own auto-restart it is a signal-based stand-in for a JVM the controller didn't spawn (issue #23), which reports liveness but not an exit code. |
 | `api_port` | int | `4001` (live) or `4002` (paper). |
 | `api_port_open` | bool | TCP-probe of `127.0.0.1:api_port` inside the container. **Note**: this probes the Gateway's real listener directly, *not* the socat forwarder — so this is the true authenticated-and-serving signal. |
 | `last_auth_success_ts` | float \| null | Wall-clock `time.time()` of the most recent successful auth. `null` until the first success in this process's lifetime. |
@@ -218,6 +218,61 @@ took longer than the configured delay — consider tuning
 **Recommended debounce**: none needed for paging (don't page). For
 INFO-tier visibility dashboards, no debounce — frequency itself is
 useful signal.
+
+### `ALERT_AUTO_RESTART`
+
+```
+ALERT_AUTO_RESTART mode=live status=adopted old_pid=27 new_pid=5020 elapsed_seconds=3 reason="API port 4001 open — session preserved across Gateway's auto-restart, no login and no second factor required"
+ALERT_AUTO_RESTART mode=live status=adopted old_pid=27 new_pid=5020 elapsed_seconds=94 reason="session not preserved; full login re-driven on the adopted JVM"
+ALERT_AUTO_RESTART mode=live status=failed_no_agent old_pid=27 new_pid=none elapsed_seconds=90 reason="no new Gateway JVM answered on /tmp/gateway-input-live.sock within 90s; falling back to a controller-driven relaunch"
+ALERT_AUTO_RESTART mode=live status=failed_api_timeout old_pid=27 new_pid=5020 elapsed_seconds=183 reason="API port 4001 did not open within 180s of adoption and no login dialog appeared; falling back to a controller-driven relaunch"
+```
+
+**When fired**: the Gateway JVM exited and install4j's
+`.install4j/restarter.log` (next to the launcher) had an mtime inside
+the last 120 s, and differed from the one the previous adoption
+attempt acted on — Gateway restarted *itself*, which is what
+`AUTO_RESTART_TIME` (Configure → Lock and Exit → Set Auto Restart
+Time) does every day. Instead of relaunching, the controller waited
+for the instance install4j brought up, adopted it, and reports the
+outcome here. One line per adoption attempt that gets as far as
+waiting for the new JVM; an attempt that stops earlier (no fresh
+`restarter.log`) emits none, and neither does an unexpected exception
+inside the path (that one is logged as `Recovery: self-restart
+adoption raised …`). Added with the issue #23 fix.
+
+**`status=` values**:
+
+| status | level | meaning |
+|---|---|---|
+| `adopted` | INFO | The self-restarted Gateway is serving again. `reason` says whether the session was preserved (API port opened with no login — the normal case) or a login dialog appeared and the full login was re-driven on the adopted JVM (e.g. IBKR's weekly full re-authentication). |
+| `failed_no_agent` | WARNING | No JVM with a new PID answered on the agent socket within `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`. The controller fell back to its own relaunch (`do_restart_in_place`). If install4j's instance then turns up *after* the fallback started, you are back in the pre-fix two-instance race for that night — check for a second `ibgateway` process if the following login fails. |
+| `failed_jvm_exited` | WARNING | The adopted JVM died before its API port opened. Fell back to a relaunch. |
+| `failed_login` | WARNING | A login dialog appeared on the adopted JVM and the re-driven login failed. A more specific token (`ALERT_LOGIN_FAILED`, `ALERT_2FA_FAILED`) usually precedes it, but not every failure path emits one. The adopted instance is torn down, then the controller falls back to a relaunch. |
+| `failed_api_timeout` | WARNING | Adopted, but the API port did not open within 180 s and no login dialog appeared. The adopted instance is torn down, then the controller falls back to a relaunch. |
+
+**What it means**: `status=adopted` is the benign nightly signal — a
+session-preserving restart that cost a few seconds and no second
+factor. Any `failed_*` status means the pre-fix behaviour (relaunch +
+cold login, and a 2FA push on IB Key accounts) took over for that
+night; the following `RESTART:` lines and tokens describe how that
+went.
+
+**What the operator should do**: nothing on `adopted`. On repeated
+`failed_no_agent`, check that the self-restarted JVM is actually
+coming up (`ps`, `/tmp/jvm_console_${TRADING_MODE}.log`) and consider
+raising `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS` on a slow host. On
+repeated `failed_api_timeout`, look at the adopted JVM's windows in
+the `AUTORESTART: API port ... still closed` progress lines. If the
+adoption path itself is suspected, `AUTO_RESTART_ADOPT=no` restores
+the always-relaunch behaviour.
+
+**Log level**: `INFO` for `adopted`, `WARNING` for the `failed_*`
+statuses. Grep on the prefix and read `status=`.
+
+**Recommended debounce**: none. One line per night per mode is the
+expected rate with `AUTO_RESTART_TIME` set; zero is expected without
+it.
 
 ### `ALERT_JVM_RESTART_EXHAUSTED`
 
@@ -608,6 +663,8 @@ set `--no-healthcheck` at runtime or patch the Dockerfile.
 | `CCP_COOLDOWN_MULTIPLIER` | `1.5` | Multiplicative factor applied per restart attempt: attempt-1 = base, attempt-2 = base×1.5, attempt-3 = base×2.25, etc., capped at `CCP_COOLDOWN_MAX_SECONDS`. Set to `1.0` to restore the v0.5.4-and-earlier fixed-duration behaviour. Added v0.5.5. |
 | `CLEAN_LOGOUT_TIMEOUT_SECONDS` | `15` | Seconds to wait for the Gateway JVM to exit after dispatching `WindowEvent.WINDOW_CLOSING` (the v0.5.6 clean-logout path). Gateway's WindowListener performs a CCP session-close, which can take a few seconds (network round-trip to IBKR + state flush). If this expires, the controller falls through to the SIGTERM path. Shorten (e.g. `7`) if Docker's `--stop-timeout` is tight; lengthen on slow-network hosts. Added v0.5.6. |
 | `CCP_LOCKOUT_MAX_JVM_RESTARTS` | `0` | Number of SIGKILL-capable JVM teardown cycles `_escalate_to_jvm_restart` will attempt before giving up. Default `0` = halt immediately and emit `ALERT_CCP_PERSISTENT_HALT` (v0.5.9's new behaviour; rationale: the retry loop can compound the lockout it's trying to clear by re-stranding slots on each teardown). Set to `5` to restore pre-v0.5.9 auto-retry behaviour. Supersedes the internal `_JVM_RESTART_MAX_ATTEMPTS` constant when set positive. Added v0.5.9. |
+| `AUTO_RESTART_ADOPT` | `yes` | When the Gateway JVM exits right after install4j's restarter ran (Gateway's own `AUTO_RESTART_TIME` restart), adopt the instance install4j brings up instead of launching a second one — no login, no second factor. `no` restores the always-relaunch behaviour that raced the restarter (issue #23). Added with the issue #23 fix. |
+| `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS` | `90` | How long to wait for the self-restarted JVM's agent to answer with a new PID before giving up on adoption and falling back to a relaunch (`ALERT_AUTO_RESTART status=failed_no_agent`). The issue #23 reporter observed 0-3 s on their host; the default leaves room for slower ones. Added with the issue #23 fix. |
 
 ## Example integrations
 
@@ -709,8 +766,10 @@ teardown diagnostic) in v0.5.6 with three initial `status=` values,
 and `ALERT_CCP_PERSISTENT_HALT` (ERROR-level, halt-and-page) plus
 four additional `ALERT_CLEAN_LOGOUT` `status=` values
 (`safe_no_session`, `zombie_slot_cannot_release`,
-`cancelled_pending_2fa`, `failed_cancel_2fa`) in v0.5.9 — all under
-the same stability contract. Breaking changes will be called out in
+`cancelled_pending_2fa`, `failed_cancel_2fa`) in v0.5.9, and
+`ALERT_AUTO_RESTART` (INFO on `status=adopted`, WARNING on the
+`failed_*` statuses) with the issue #23 fix — all under the same
+stability contract. Breaking changes will be called out in
 the CHANGELOG and accompany a minor version bump. Adding new fields
 to `/health`, new `ALERT_*` tokens, or new `status=` values to
 existing tokens is not a breaking change.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -222,20 +222,34 @@ useful signal.
 ### `ALERT_AUTO_RESTART`
 
 ```
-ALERT_AUTO_RESTART mode=live status=adopted old_pid=27 new_pid=5020 elapsed_seconds=3 reason="API port 4001 open — session preserved across Gateway's auto-restart, no login and no second factor required"
-ALERT_AUTO_RESTART mode=live status=adopted old_pid=27 new_pid=5020 elapsed_seconds=94 reason="session not preserved; full login re-driven on the adopted JVM"
-ALERT_AUTO_RESTART mode=live status=failed_no_agent old_pid=27 new_pid=none elapsed_seconds=90 reason="no new Gateway JVM answered on /tmp/gateway-input-live.sock within 90s; falling back to a controller-driven relaunch"
-ALERT_AUTO_RESTART mode=live status=failed_api_timeout old_pid=27 new_pid=5020 elapsed_seconds=183 reason="API port 4001 did not open within 180s of adoption and no login dialog appeared; falling back to a controller-driven relaunch"
+ALERT_AUTO_RESTART mode=live status=adopted detected_via=restarter_log old_pid=27 new_pid=5020 elapsed_seconds=3 reason="API port 4001 open — session preserved across Gateway's auto-restart, no login and no second factor required"
+ALERT_AUTO_RESTART mode=live status=adopted detected_via=agent_socket old_pid=27 new_pid=5020 elapsed_seconds=6 reason="API port 4001 open — session preserved across Gateway's auto-restart, no login and no second factor required"
+ALERT_AUTO_RESTART mode=live status=adopted detected_via=restarter_log old_pid=27 new_pid=5020 elapsed_seconds=94 reason="session not preserved; full login re-driven on the adopted JVM"
+ALERT_AUTO_RESTART mode=live status=failed_no_agent detected_via=restarter_log old_pid=27 new_pid=none elapsed_seconds=90 reason="no new Gateway JVM answered on /tmp/gateway-input-live.sock within 90s; falling back to a controller-driven relaunch"
+ALERT_AUTO_RESTART mode=live status=failed_api_timeout detected_via=restarter_log old_pid=27 new_pid=5020 elapsed_seconds=183 reason="API port 4001 did not open within 180s of adoption and no login dialog appeared; falling back to a controller-driven relaunch"
 ```
 
-**When fired**: the Gateway JVM exited and install4j's
-`.install4j/restarter.log` (next to the launcher) had an mtime inside
-the last 120 s, and differed from the one the previous adoption
-attempt acted on — Gateway restarted *itself*, which is what
-`AUTO_RESTART_TIME` (Configure → Lock and Exit → Set Auto Restart
-Time) does every day. Instead of relaunching, the controller waited
-for the instance install4j brought up, adopted it, and reports the
-outcome here. One line per adoption attempt that gets as far as
+**When fired**: the Gateway JVM exited and the controller concluded
+Gateway was restarting *itself* — which is what `AUTO_RESTART_TIME`
+(Configure → Lock and Exit → Set Auto Restart Time) makes it do every
+day. Instead of relaunching, the controller waited for the instance
+install4j brought up, adopted it, and reports the outcome here.
+
+`detected_via=` says which signal fired:
+
+- **`restarter_log`** — install4j's `.install4j/restarter.log` (next to
+  the launcher) has an mtime inside the last 120 s and differs from the
+  one the previous adoption attempt acted on. The fast, unambiguous
+  case.
+- **`agent_socket`** — no usable `restarter.log`, but after a clean exit
+  a live Gateway JVM the controller never spawned was already answering
+  on the agent socket within `AUTO_RESTART_PROBE_SECONDS`. Not every
+  install4j build writes the log (verified: Gateway 10.45.1g's restarter
+  writes none; the issue #23 reporter's 10.45.1j writes one), so this is
+  the fallback that keeps the fix working where the log never appears.
+  Only a running JVM can answer that socket, so a reply from a PID that
+  isn't ours is direct evidence — and launching a second instance in
+  that state is precisely the issue #23 bug. One line per adoption attempt that gets as far as
 waiting for the new JVM; an attempt that stops earlier (no fresh
 `restarter.log`) emits none, and neither does an unexpected exception
 inside the path (that one is logged as `Recovery: self-restart
@@ -664,6 +678,7 @@ set `--no-healthcheck` at runtime or patch the Dockerfile.
 | `CLEAN_LOGOUT_TIMEOUT_SECONDS` | `15` | Seconds to wait for the Gateway JVM to exit after dispatching `WindowEvent.WINDOW_CLOSING` (the v0.5.6 clean-logout path). Gateway's WindowListener performs a CCP session-close, which can take a few seconds (network round-trip to IBKR + state flush). If this expires, the controller falls through to the SIGTERM path. Shorten (e.g. `7`) if Docker's `--stop-timeout` is tight; lengthen on slow-network hosts. Added v0.5.6. |
 | `CCP_LOCKOUT_MAX_JVM_RESTARTS` | `0` | Number of SIGKILL-capable JVM teardown cycles `_escalate_to_jvm_restart` will attempt before giving up. Default `0` = halt immediately and emit `ALERT_CCP_PERSISTENT_HALT` (v0.5.9's new behaviour; rationale: the retry loop can compound the lockout it's trying to clear by re-stranding slots on each teardown). Set to `5` to restore pre-v0.5.9 auto-retry behaviour. Supersedes the internal `_JVM_RESTART_MAX_ATTEMPTS` constant when set positive. Added v0.5.9. |
 | `AUTO_RESTART_ADOPT` | `yes` | When the Gateway JVM exits right after install4j's restarter ran (Gateway's own `AUTO_RESTART_TIME` restart), adopt the instance install4j brings up instead of launching a second one — no login, no second factor. `no` restores the always-relaunch behaviour that raced the restarter (issue #23). Added with the issue #23 fix. |
+| `AUTO_RESTART_PROBE_SECONDS` | `15` | When a clean JVM exit leaves no fresh `restarter.log`, how long to ask the agent socket whether a Gateway JVM the controller didn't spawn is already running (`ALERT_AUTO_RESTART detected_via=agent_socket`). Set to `0` to detect self-restarts only via `restarter.log`. This is the worst-case delay added to a genuine crash recovery on a clean exit, alongside the 5 s late-log grace. Added with the issue #23 fix. |
 | `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS` | `90` | How long to wait for the self-restarted JVM's agent to answer with a new PID before giving up on adoption and falling back to a relaunch (`ALERT_AUTO_RESTART status=failed_no_agent`). The issue #23 reporter observed 0-3 s on their host; the default leaves room for slower ones. Added with the issue #23 fix. |
 
 ## Example integrations

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -243,13 +243,20 @@ install4j brought up, adopted it, and reports the outcome here.
   case.
 - **`agent_socket`** — no usable `restarter.log`, but after a clean exit
   a live Gateway JVM the controller never spawned was already answering
-  on the agent socket within `AUTO_RESTART_PROBE_SECONDS`. Not every
-  install4j build writes the log (verified: Gateway 10.45.1g's restarter
-  writes none; the issue #23 reporter's 10.45.1j writes one), so this is
-  the fallback that keeps the fix working where the log never appears.
-  Only a running JVM can answer that socket, so a reply from a PID that
-  isn't ours is direct evidence — and launching a second instance in
-  that state is precisely the issue #23 bug. One line per adoption attempt that gets as far as
+  on the agent socket within `AUTO_RESTART_PROBE_SECONDS`. The restarter
+  writes its log to a path *relative* to its working directory, so the
+  log is expected but not guaranteed; this is the fallback that keeps
+  the fix working where it doesn't appear. Only a running JVM can answer
+  that socket, so a reply from a PID that isn't ours is direct evidence
+  — and launching a second instance in that state is precisely the issue
+  #23 bug.
+- **`install4j_restarter`** — install4j's restarter was itself found
+  holding the agent socket. It is a JVM that inherits the same
+  `-javaagent`, so it binds the socket and answers `GET_PID` with its
+  own PID for the seconds it lives. That is conclusive evidence of a
+  self-restart. The controller identifies it by its
+  `-Dinstall4j.alternativeLogfile` flag, never adopts it, and waits for
+  the Gateway JVM it launches. One line per adoption attempt that gets as far as
 waiting for the new JVM; an attempt that stops earlier (no fresh
 `restarter.log`) emits none, and neither does an unexpected exception
 inside the path (that one is logged as `Recovery: self-restart

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -87,7 +87,15 @@ anything from you.
   in a cold login every night. **Default-on behaviour change.** If you
   need the old behaviour, set `AUTO_RESTART_ADOPT=no`.
   - New env vars: `AUTO_RESTART_ADOPT` (default `yes`),
-    `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS` (default `90`).
+    `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS` (default `90`),
+    `AUTO_RESTART_PROBE_SECONDS` (default `15`).
+  - **Small added latency on clean exits.** When a code-0 exit leaves no
+    fresh `restarter.log`, the controller spends up to 5 s re-checking
+    for a late one and up to `AUTO_RESTART_PROBE_SECONDS` asking the
+    agent socket whether a Gateway JVM it didn't spawn is already
+    running, before falling through to the relaunch. Worst case ~20 s
+    added to a clean-exit recovery; crashes (non-zero exit) are
+    unaffected. Set `AUTO_RESTART_PROBE_SECONDS=0` to drop the probe.
   - New log token: `ALERT_AUTO_RESTART` (INFO on `status=adopted`,
     WARNING on the `failed_*` statuses). Grep-by-prefix monitors need
     no change; add it if you want nightly visibility.
@@ -98,9 +106,9 @@ anything from you.
     `AUTORESTART:` lines above it.
   - Pure Python, no agent-jar change — pull the new image or, if you
     build from source, `make`.
-  - Does not apply if you don't set `AUTO_RESTART_TIME`: with no
-    Gateway self-restart there is no `restarter.log`, and every exit
-    takes the existing recovery path unchanged.
+  - If you don't set `AUTO_RESTART_TIME`, Gateway never restarts
+    itself, so neither signal fires and every exit takes the existing
+    recovery path — apart from the added detection delay above.
 
 ### v0.8.1
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,6 +76,32 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
+### Unreleased
+
+- **If you set `AUTO_RESTART_TIME`, the controller no longer relaunches
+  Gateway after Gateway's own daily restart (issue #23).** It detects
+  install4j's restarter (by the mtime of `.install4j/restarter.log`
+  next to the launcher), waits for the instance Gateway is bringing up,
+  adopts it, and resumes monitoring — typically a few seconds, with no
+  login and no second factor, instead of the previous race that ended
+  in a cold login every night. **Default-on behaviour change.** If you
+  need the old behaviour, set `AUTO_RESTART_ADOPT=no`.
+  - New env vars: `AUTO_RESTART_ADOPT` (default `yes`),
+    `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS` (default `90`).
+  - New log token: `ALERT_AUTO_RESTART` (INFO on `status=adopted`,
+    WARNING on the `failed_*` statuses). Grep-by-prefix monitors need
+    no change; add it if you want nightly visibility.
+  - Watch for on the first night after upgrading:
+    `ALERT_AUTO_RESTART mode=… status=adopted` at your configured
+    restart time. A `failed_*` status means the controller fell back to
+    the pre-fix relaunch for that night — the details are in the
+    `AUTORESTART:` lines above it.
+  - Pure Python, no agent-jar change — pull the new image or, if you
+    build from source, `make`.
+  - Does not apply if you don't set `AUTO_RESTART_TIME`: with no
+    Gateway self-restart there is no `restarter.log`, and every exit
+    takes the existing recovery path unchanged.
+
 ### v0.8.1
 
 - **Passkey/WebAuthn accounts now fail loudly instead of hanging

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -235,6 +235,18 @@ TEST_MODE = os.environ.get("CONTROLLER_TEST_MODE", "") == "1"
 # apps are present simultaneously. Stays None until the agent is up.
 JVM_PID = None
 
+# Absolute path of the install4j launcher script the controller spawned
+# (set by launch_gateway). Used to find install4j's
+# ``.install4j/restarter.log`` next to it when deciding whether a JVM
+# exit was Gateway's own daily auto-restart (issue #23).
+_GATEWAY_LAUNCHER_PATH = None
+
+# mtime of the install4j restarter.log that the last adoption attempt
+# acted on. A restarter.log stays "fresh" for 120s, so without this an
+# adopted JVM that dies inside that window would send the controller
+# through a second pointless adoption wait for the same restart.
+_LAST_ADOPTED_RESTART_MTIME = None
+
 # The Gateway JVM subprocess and its AT-SPI application accessible.
 # Made module-global so the Phase 2.4 command server's RESTART handler
 # can tear down the current JVM and re-launch + re-login in place,
@@ -995,10 +1007,12 @@ def launch_gateway():
         that would otherwise route Gateway's writes to /root/Jts (which
         fails for the non-root ibgateway user)
     """
+    global _GATEWAY_LAUNCHER_PATH
     launcher = find_gateway_launcher()
     if launcher is None:
         log.error(f"No Gateway launcher found under {TWS_PATH}/ibgateway")
         sys.exit(1)
+    _GATEWAY_LAUNCHER_PATH = launcher
     log.info(f"Gateway launcher: {launcher}")
     log.info(f"Gateway config dir (jtsConfigDir): {JTS_CONFIG_DIR}")
 
@@ -2714,6 +2728,54 @@ _CCP_MAINTENANCE_RECOVERY_DELAY_SECONDS = int(os.environ.get(
     "CCP_MAINTENANCE_RECOVERY_DELAY_SECONDS",
     str(_CCP_MAINTENANCE_RECOVERY_DELAY_SECONDS_DEFAULT)))
 
+# Issue #23: Gateway's own daily auto-restart (Configure → Lock and Exit →
+# "Set Auto Restart Time", i.e. AUTO_RESTART_TIME). At that time the JVM
+# spawns install4j's `.install4j/restarter`, which shuts the calling
+# launcher down and re-executes it; the replacement re-uses the current
+# session's credentials, so no login and no second factor are needed.
+# monitor_loop saw that code-0 exit as a crash and do_restart_in_place
+# launched a SECOND Gateway ~2s before install4j launched its own — two
+# instances on one display and one settings dir, the agent drove the
+# wrong window, login failed, the controller halted and the container
+# restarted into a cold login (and a 2FA push) every night. The fix:
+# when install4j's restarter.log was just written, don't launch
+# anything — wait for the instance install4j is bringing up, adopt it
+# (it inherits INSTALL4J_ADD_VM_PARAMS through the restarter, so its
+# agent binds our socket and reports its PID) and resume monitoring.
+#
+# AUTO_RESTART_ADOPT=no restores the previous always-relaunch behaviour.
+# Every failure inside the adoption path falls through to the
+# controller-driven restart, so the worst case is the old behaviour
+# plus the adopt timeout.
+_AUTO_RESTART_ADOPT = _coerce_yes_no(
+    os.environ.get("AUTO_RESTART_ADOPT", "yes")) is not False
+# How long to wait for the self-restarted JVM's agent to report a new
+# PID over the inherited agent socket. Measured ~0-3s in production
+# (issue #23); the default leaves room for slow hosts.
+_AUTO_RESTART_ADOPT_TIMEOUT_SECONDS = int(os.environ.get(
+    "AUTO_RESTART_ADOPT_TIMEOUT_SECONDS", "90"))
+# restarter.log must have been written this recently for a JVM exit to
+# count as a self-restart. The trigger is install4j's own file, not the
+# wall-clock vs AUTO_RESTART_TIME: that comparison would have to guess
+# which timezone Gateway's Lock-and-Exit field is in (jts.ini carries
+# its own TimeZone, the container another) and would fire on any code-0
+# exit that happened to land in the window.
+_AUTO_RESTART_DETECT_WINDOW_SECONDS = 120
+# After a clean (code-0) exit, keep re-checking restarter.log for this
+# long before concluding the exit was not a self-restart: the
+# restarter's first write can trail the JVM exit by a couple of seconds
+# and monitor_loop polls every 5s.
+_AUTO_RESTART_DETECT_GRACE_SECONDS = 5
+# After adoption, how long to wait for the API port (session preserved)
+# or a login dialog (session not preserved, e.g. IBKR's weekly full
+# re-authentication) before falling back to a relaunch.
+_AUTO_RESTART_API_TIMEOUT_SECONDS = 180
+# Exit status reported by _AdoptedProcess for a JVM the controller did
+# not spawn: waitpid() only works on children, so the real code is not
+# observable. Deliberately not an int so it can never be mistaken for a
+# real exit code.
+_EXIT_STATUS_UNOBSERVABLE = "unobservable"
+
 
 def _compute_adaptive_cooldown(attempt, base_seconds, multiplier, max_seconds):
     """Pure-logic helper: scale the CCP cool-down by restart-attempt index.
@@ -2818,6 +2880,331 @@ def _apply_maintenance_recovery_delay(reason):
     log.info("Maintenance-window delay complete; proceeding with recovery")
 
 
+# ── Gateway self-restart adoption (issue #23) ──────────────────────────
+
+def _proc_stat(pid):
+    """Return ``(state, starttime)`` from ``/proc/<pid>/stat``, or ``None``
+    when /proc is unavailable (macOS test hosts) or the entry is gone.
+
+    ``state`` is the kernel's one-letter process state (``Z`` = zombie);
+    ``starttime`` is the process start time in clock ticks since boot,
+    which together with the PID identifies one process instance.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as f:
+            raw = f.read().decode("utf-8", errors="replace")
+    except (OSError, ValueError):
+        return None
+    # Field 2 (comm) is parenthesised and may contain spaces; split
+    # after the LAST ')' so rest[0] is field 3 (state) and rest[19] is
+    # field 22 (starttime).
+    try:
+        rest = raw[raw.rindex(")") + 2:].split()
+        return rest[0], int(rest[19])
+    except (ValueError, IndexError):
+        return None
+
+
+class _AdoptedProcess:
+    """Popen-shaped stand-in for a Gateway JVM the controller did not spawn.
+
+    Issue #23: after Gateway's own daily auto-restart the replacement JVM
+    is install4j's child, not ours, so there is no ``subprocess.Popen``
+    to poll. This class gives ``GATEWAY_PROC`` the surface the rest of
+    the controller uses (``pid``, ``poll()``, ``returncode``,
+    ``terminate()``, ``kill()``, ``wait()``) backed by signals:
+    ``os.kill(pid, 0)`` for liveness, plus ``/proc`` (when present) to
+    treat a zombie as exited and to detect PID reuse via the kernel
+    start time captured at adoption.
+
+    ``waitpid`` only works on children, so the real exit status is not
+    observable: ``poll()`` / ``returncode`` report
+    ``_EXIT_STATUS_UNOBSERVABLE`` once the process is gone.
+    """
+
+    def __init__(self, pid):
+        self.pid = int(pid)
+        self.returncode = None
+        stat = _proc_stat(self.pid)
+        self._starttime = stat[1] if stat is not None else None
+
+    def _alive(self):
+        try:
+            os.kill(self.pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # Exists but we may not signal it; let /proc decide below
+            # (a PID reused by another user's process fails the
+            # start-time check).
+            pass
+        stat = _proc_stat(self.pid)
+        if stat is None:
+            return True  # no /proc: trust kill(0)
+        state, starttime = stat
+        if state in ("Z", "X"):
+            return False
+        if self._starttime is not None and starttime != self._starttime:
+            return False  # PID reused by a different process
+        return True
+
+    def poll(self):
+        if self.returncode is None and not self._alive():
+            self.returncode = _EXIT_STATUS_UNOBSERVABLE
+        return self.returncode
+
+    def wait(self, timeout=None):
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while self.poll() is None:
+            if deadline is not None and time.monotonic() >= deadline:
+                raise subprocess.TimeoutExpired(f"pid {self.pid}", timeout)
+            time.sleep(0.1)
+        return self.returncode
+
+    def _signal(self, sig):
+        # Identity check first: this PID is not our child, so between
+        # adoption and here the kernel could have recycled it onto an
+        # unrelated process. _alive() compares /proc start time against
+        # the one captured at adoption.
+        if not self._alive():
+            return
+        try:
+            os.kill(self.pid, sig)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    def terminate(self):
+        self._signal(signal.SIGTERM)
+
+    def kill(self):
+        self._signal(signal.SIGKILL)
+
+    def __repr__(self):
+        return f"<_AdoptedProcess pid={self.pid} returncode={self.returncode!r}>"
+
+
+def _install4j_restarter_log_path():
+    """Path of install4j's ``restarter.log`` for the launcher we spawned
+    (``<launcher dir>/.install4j/restarter.log``), or ``None`` if no
+    launcher is known."""
+    launcher = _GATEWAY_LAUNCHER_PATH or find_gateway_launcher()
+    if not launcher:
+        return None
+    return os.path.join(os.path.dirname(launcher), ".install4j",
+                        "restarter.log")
+
+
+def _install4j_restarter_mtime():
+    """mtime of install4j's ``restarter.log``, or ``None`` if unreadable."""
+    path = _install4j_restarter_log_path()
+    if path is None:
+        return None
+    try:
+        return os.stat(path).st_mtime
+    except OSError:
+        return None
+
+
+def _install4j_restarter_age(now=None):
+    """Seconds since install4j's restarter last wrote its log, or ``None``
+    if the log is missing or older than
+    ``_AUTO_RESTART_DETECT_WINDOW_SECONDS``.
+
+    install4j having just written that file is the restarter's own
+    statement that it ran — the only trigger used for self-restart
+    detection (issue #23). A stale file from yesterday's restart, or one
+    left behind on a persistent settings volume, is ignored.
+    """
+    mtime = _install4j_restarter_mtime()
+    if mtime is None:
+        return None
+    age = (time.time() if now is None else now) - mtime
+    if age > _AUTO_RESTART_DETECT_WINDOW_SECONDS:
+        return None
+    if age < -_AUTO_RESTART_DETECT_WINDOW_SECONDS:
+        # Dated far in the future — a clock skew between the container
+        # and the settings volume, not a restart in progress. Treating
+        # it as fresh would send every clean exit through the adoption
+        # wait forever.
+        return None
+    return max(age, 0.0)
+
+
+def _wait_for_self_restarted_agent(old_pid, timeout, exclude=()):
+    """Poll the agent socket until a JVM with a PID other than ``old_pid``
+    (and not in ``exclude``) answers ``GET_PID``. Returns the new PID, or
+    ``None`` on timeout.
+
+    ``exclude`` carries PIDs already tried and found dead, so a second
+    attempt doesn't re-adopt a transient JVM from the restarter chain.
+
+    The self-restarted JVM inherits ``INSTALL4J_ADD_VM_PARAMS`` through
+    the restarter, so it loads the same ``-javaagent`` with the same
+    socket path, and the agent's own ``Files.deleteIfExists`` + bind
+    replaces the dead JVM's socket file. This side must NOT unlink the
+    socket: doing so after the new agent has bound would orphan its
+    listener and the controller could never reach the adopted JVM.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if agent_wait_ready(timeout=1):
+            pid = agent_get_pid()
+            if (pid is not None and pid != old_pid and pid not in exclude
+                    and pid > 1 and pid != os.getpid()):
+                return pid
+        time.sleep(0.5)
+    return None
+
+
+def _adopt_self_restarted_gateway(reason, *, exit_code=None):
+    """Issue #23: if the JVM exit that triggered recovery was Gateway's
+    own daily auto-restart, adopt the instance install4j is bringing up
+    instead of launching a second one.
+
+    Returns True when the adopted Gateway is serving again (API port
+    open because the session was preserved, or re-login driven when it
+    was not) and monitoring can resume. Returns False to fall through
+    to the controller-driven restart. By then ``GATEWAY_PROC`` may point
+    at the adopted instance so the fallback's teardown terminates it
+    first, instead of no-op'ing on the dead ``Popen`` and leaving two
+    Gateways up. Expected failure modes never raise.
+
+    Emits ``ALERT_AUTO_RESTART`` with ``status=adopted`` (INFO) or one
+    of the ``failed_*`` statuses (WARNING); see docs/OBSERVABILITY.md.
+    """
+    global GATEWAY_PROC, CURRENT_APP, JVM_PID, _command_server_app
+    global _LAST_ADOPTED_RESTART_MTIME
+
+    old_pid = JVM_PID
+    age = _install4j_restarter_age()
+    if age is None and exit_code in (0, _EXIT_STATUS_UNOBSERVABLE):
+        grace_deadline = time.monotonic() + _AUTO_RESTART_DETECT_GRACE_SECONDS
+        while age is None and time.monotonic() < grace_deadline:
+            time.sleep(0.5)
+            age = _install4j_restarter_age()
+    if age is None:
+        return False
+
+    mtime = _install4j_restarter_mtime()
+    if mtime is not None and mtime == _LAST_ADOPTED_RESTART_MTIME:
+        # Same restart we already handled: the adopted JVM came up and
+        # then died inside the 120s freshness window. That's a failure
+        # of the restarted instance, not a restart in progress — go
+        # straight to the controller-driven relaunch.
+        log.info("AUTORESTART: restarter.log unchanged since the last "
+                 "adoption attempt — treating this exit as a real "
+                 "failure, not another self-restart")
+        return False
+
+    log.info(f"AUTORESTART: install4j restarter ran {age:.0f}s ago "
+             f"({_install4j_restarter_log_path()})")
+    log.warning(f"AUTORESTART: Gateway is restarting itself — NOT launching "
+                f"a second instance (old pid={old_pid}); waiting up to "
+                f"{_AUTO_RESTART_ADOPT_TIMEOUT_SECONDS}s for the new JVM's "
+                f"agent on {AGENT_SOCKET}")
+    _LAST_ADOPTED_RESTART_MTIME = mtime
+    t0 = time.monotonic()
+
+    def _alert(level, status, new_pid, why):
+        level(f"ALERT_AUTO_RESTART mode={TRADING_MODE} status={status} "
+              f"old_pid={old_pid} new_pid={new_pid} "
+              f"elapsed_seconds={time.monotonic() - t0:.0f} "
+              f"reason=\"{why}\"")
+
+    api_port = api_port_for_mode()
+    # install4j's restarter chain can briefly show a JVM that isn't the
+    # replacement Gateway. If the first candidate dies before its API
+    # port opens, try once more for whatever is left of the budget
+    # rather than falling straight through to a relaunch.
+    tried = set()
+    adopt_deadline = time.monotonic() + _AUTO_RESTART_ADOPT_TIMEOUT_SECONDS
+    while True:
+        wait_budget = max(1.0, adopt_deadline - time.monotonic())
+        new_pid = _wait_for_self_restarted_agent(
+            old_pid, wait_budget, exclude=tried)
+        if new_pid is None or new_pid in tried:
+            _alert(log.warning, "failed_no_agent", "none",
+                   f"no new Gateway JVM answered on {AGENT_SOCKET} within "
+                   f"{_AUTO_RESTART_ADOPT_TIMEOUT_SECONDS}s; falling back to a "
+                   "controller-driven relaunch")
+            return False
+        tried.add(new_pid)
+
+        # Repoint GATEWAY_PROC BEFORE the API-port wait: if the port never
+        # opens, the fallback's _teardown_jvm_for_restart then cleanly kills
+        # the adopted instance before relaunching.
+        GATEWAY_PROC = _AdoptedProcess(new_pid)
+        JVM_PID = new_pid
+        new_app = find_app(APP_NAME_CANDIDATES, timeout=120, match_pid=new_pid)
+        CURRENT_APP = new_app
+        _command_server_app = new_app
+        log.info(f"AUTORESTART: adopted Gateway pid={new_pid} (was {old_pid}) "
+                 f"after {time.monotonic() - t0:.0f}s")
+
+        deadline = time.monotonic() + _AUTO_RESTART_API_TIMEOUT_SECONDS
+        last_status = time.monotonic()
+        died = False
+        while time.monotonic() < deadline:
+            if GATEWAY_PROC.poll() is not None:
+                died = True
+                break
+            if is_api_port_open(api_port):
+                _alert(log.info, "adopted", new_pid,
+                       f"API port {api_port} open — session preserved across "
+                       "Gateway's auto-restart, no login and no second factor "
+                       "required")
+                signal_ready()
+                return True
+            texts, buttons = agent_list()
+            if "Username" in texts or "Password" in texts:
+                log.info("AUTORESTART: login dialog on the self-restarted "
+                         "Gateway — the session was not preserved (e.g. IBKR's "
+                         "weekly full re-authentication); re-driving login")
+                # AUTO_RESTART_TIME commonly sits inside IBKR's nightly
+                # maintenance window. Adoption itself needs no auth, but
+                # this branch does, so the v0.5.10 drain guard applies.
+                if _is_ibkr_maintenance_window():
+                    _apply_maintenance_recovery_delay(
+                        "self-restarted Gateway needs a full re-login")
+                if _redrive_login(new_app):
+                    _alert(log.info, "adopted", new_pid,
+                           "session not preserved; full login re-driven on the "
+                           "adopted JVM")
+                    return True
+                _alert(log.warning, "failed_login", new_pid,
+                       "login on the adopted Gateway failed; falling back to a "
+                       "controller-driven relaunch")
+                return False
+            # Same opportunistic disclaimer handling as wait_for_api_port.
+            for btn in SAFE_DISMISS_BUTTONS:
+                if btn in buttons:
+                    log.info(f"  dismissing disclaimer {btn!r}")
+                    agent_click(btn)
+                    time.sleep(0.5)
+            now = time.monotonic()
+            if now - last_status > 10:
+                log.info(f"AUTORESTART: API port {api_port} still closed at "
+                         f"t+{now - t0:.0f}s; windows={agent_windows()}")
+                last_status = now
+            time.sleep(1)
+
+        if died and time.monotonic() < adopt_deadline:
+            log.warning(f"AUTORESTART: adopted pid={new_pid} exited before its "
+                        "API port opened; looking for another instance from "
+                        "the restarter chain")
+            continue
+        if died:
+            _alert(log.warning, "failed_jvm_exited", new_pid,
+                   "adopted Gateway JVM exited before its API port opened; "
+                   "falling back to a controller-driven relaunch")
+            return False
+        _alert(log.warning, "failed_api_timeout", new_pid,
+               f"API port {api_port} did not open within "
+               f"{_AUTO_RESTART_API_TIMEOUT_SECONDS}s of adoption and no login "
+               "dialog appeared; falling back to a controller-driven relaunch")
+        return False
+
+
 def _recover_jvm_or_escalate(reason, *, exit_code=None):
     """v0.4.7: Attempt a fast in-place JVM restart; on failure fall
     through to ``_escalate_to_jvm_restart`` (long CCP cool-down).
@@ -2850,8 +3237,37 @@ def _recover_jvm_or_escalate(reason, *, exit_code=None):
     off a CCP-lockout cascade on both modes. Non-zero exits bypass the
     guard — they're crashes, not maintenance shutdowns, and should
     recover fast.
+
+    Issue #23: before either of those, if the old JVM is gone and
+    install4j's restarter just ran, ``_adopt_self_restarted_gateway``
+    adopts the instance Gateway is bringing up itself (no relaunch, no
+    login, no second factor). Ordered ahead of the maintenance guard on
+    purpose: AUTO_RESTART_TIME commonly sits inside that window, and an
+    8-minute sleep would be pointless when there is nothing to re-auth.
+    ``_EXIT_STATUS_UNOBSERVABLE`` (an adopted JVM's exit — its real code
+    can't be observed) is treated like 0 by the guard: the conservative
+    choice, since the common cause of an adopted JVM exiting is the same
+    cooperative shutdown.
     """
-    if exit_code == 0 and _is_ibkr_maintenance_window():
+    if _AUTO_RESTART_ADOPT and (GATEWAY_PROC is None
+                                or GATEWAY_PROC.poll() is not None):
+        try:
+            if _adopt_self_restarted_gateway(reason, exit_code=exit_code):
+                log.info("Recovery: adopted Gateway's self-restarted JVM; "
+                         "no relaunch needed")
+                return True
+        except Exception as e:
+            log.error(f"Recovery: self-restart adoption raised "
+                      f"{type(e).__name__}: {e}; falling back to relaunch")
+        if isinstance(GATEWAY_PROC, _AdoptedProcess) and GATEWAY_PROC.poll() is None:
+            # Half-adopted instance is still up: take it down now so no
+            # second Gateway lingers through any delay below, and the
+            # relaunch starts from a clean slate.
+            log.warning("AUTORESTART: tearing down the adopted Gateway "
+                        f"pid={GATEWAY_PROC.pid} before the fallback relaunch")
+            _teardown_jvm_for_restart()
+
+    if exit_code in (0, _EXIT_STATUS_UNOBSERVABLE) and _is_ibkr_maintenance_window():
         _apply_maintenance_recovery_delay(reason)
 
     log.warning(f"Recovery: {reason}. Trying fast in-place restart first.")
@@ -4520,7 +4936,17 @@ def monitor_loop(app):
         # JVM process check — fast, every iteration
         if gw is None or gw.poll() is not None:
             rc = gw.returncode if gw is not None else 1
-            log.error(f"Gateway JVM exited with code {rc}")
+            if isinstance(gw, _AdoptedProcess):
+                # Issue #23: not our child, so waitpid can't tell us the
+                # exit status. Its next self-restart is still detected
+                # via restarter.log, not via the exit code.
+                log.error(f"Gateway JVM pid={gw.pid} exited (exit status "
+                          "not observable: adopted after Gateway's "
+                          "self-restart, not a child of the controller)")
+                reason = "adopted Gateway JVM exited"
+            else:
+                log.error(f"Gateway JVM exited with code {rc}")
+                reason = f"JVM exited with code {rc}"
             try:
                 os.unlink(READY_FILE)
             except FileNotFoundError:
@@ -4533,8 +4959,7 @@ def monitor_loop(app):
             # falls through to long cool-down if CCP is actually locked.
             # v0.5.10: pass exit_code so the recovery path can apply the
             # IBKR maintenance-window guard when rc==0.
-            _recover_jvm_or_escalate(
-                f"JVM exited with code {rc}", exit_code=rc)
+            _recover_jvm_or_escalate(reason, exit_code=rc)
             consecutive_failures = 0
             wedged_failures = 0
             last_heartbeat = time.monotonic()
@@ -4631,6 +5056,16 @@ def attempt_reauth(app):
         return True
 
     log.info("Login dialog detected during monitor loop — re-driving login")
+    return _redrive_login(app)
+
+
+def _redrive_login(app):
+    """Re-drive the full login pipeline on a login dialog that is already
+    showing. Split out of ``attempt_reauth`` (issue #23) so the
+    self-restart adoption path can drive a login on the adopted JVM
+    when Gateway did not preserve the session. Returns True if re-auth
+    completed (or a CCP backoff was applied and the monitor loop should
+    simply retry), False if it definitively failed."""
     # Refresh the app reference (the old one may have gone stale).
     # Scope to our own JVM so dual-mode containers don't cross-drive the
     # other instance's login.

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -2761,6 +2761,18 @@ _AUTO_RESTART_ADOPT_TIMEOUT_SECONDS = int(os.environ.get(
 # its own TimeZone, the container another) and would fire on any code-0
 # exit that happened to land in the window.
 _AUTO_RESTART_DETECT_WINDOW_SECONDS = 120
+# Not every install4j build writes restarter.log. Verified 2026-09-06 on
+# Gateway 10.45.1g: the .install4j/restarter binary ships and runs, but
+# invoking it produces no restarter.log, while the issue #23 reporter's
+# 10.45.1j box writes one with install4j action-log content. So the log
+# is the fast, unambiguous signal — not the only one. When it is absent
+# or stale after a clean exit, the controller spends this long asking
+# the agent socket a more direct question: is a live Gateway JVM that we
+# did not spawn already answering on it? A yes means Gateway restarted
+# itself no matter what install4j logged, and launching a second
+# instance is precisely the issue #23 bug.
+_AUTO_RESTART_PROBE_SECONDS = int(os.environ.get(
+    "AUTO_RESTART_PROBE_SECONDS", "15"))
 # After a clean (code-0) exit, keep re-checking restarter.log for this
 # long before concluding the exit was not a self-restart: the
 # restarter's first write can trail the JVM exit by a couple of seconds
@@ -2929,6 +2941,19 @@ class _AdoptedProcess:
         self._starttime = stat[1] if stat is not None else None
 
     def _alive(self):
+        # If this PID happens to be our child after all (it isn't in
+        # production, where install4j spawned it — but it is in the
+        # end-to-end tests), reap it so its exit is observable. On a
+        # non-child this raises ECHILD and we fall through to the
+        # signal- and /proc-based checks below. Without this, a dead
+        # JVM on a host with no /proc looks alive forever and teardown
+        # burns its full SIGTERM grace on a process that is already gone.
+        try:
+            reaped, _ = os.waitpid(self.pid, os.WNOHANG)
+            if reaped == self.pid:
+                return False
+        except (ChildProcessError, OSError):
+            pass
         try:
             os.kill(self.pid, 0)
         except ProcessLookupError:
@@ -3076,17 +3101,42 @@ def _adopt_self_restarted_gateway(reason, *, exit_code=None):
     global _LAST_ADOPTED_RESTART_MTIME
 
     old_pid = JVM_PID
+    clean_exit = exit_code in (0, _EXIT_STATUS_UNOBSERVABLE)
     age = _install4j_restarter_age()
-    if age is None and exit_code in (0, _EXIT_STATUS_UNOBSERVABLE):
+    if age is None and clean_exit:
         grace_deadline = time.monotonic() + _AUTO_RESTART_DETECT_GRACE_SECONDS
         while age is None and time.monotonic() < grace_deadline:
             time.sleep(0.5)
             age = _install4j_restarter_age()
+
+    first_candidate = None
     if age is None:
-        return False
+        # No usable restarter.log. On a crash, stop here — that is a
+        # genuine failure and the relaunch path owns it.
+        if not clean_exit or _AUTO_RESTART_PROBE_SECONDS <= 0:
+            return False
+        # On a clean exit, ask the agent socket directly before
+        # relaunching. Only a running JVM answers it (a dead one leaves
+        # the socket file behind but nothing listening), so a reply from
+        # a PID that is not ours is positive evidence of a self-restart.
+        log.info("AUTORESTART: no fresh install4j restarter.log; probing "
+                 f"{AGENT_SOCKET} for up to {_AUTO_RESTART_PROBE_SECONDS}s "
+                 "in case Gateway restarted itself anyway")
+        first_candidate = _wait_for_self_restarted_agent(
+            old_pid, _AUTO_RESTART_PROBE_SECONDS)
+        if first_candidate is None:
+            return False
+        detected_via = "agent_socket"
+        log.warning(f"AUTORESTART: a Gateway JVM we did not spawn "
+                    f"(pid={first_candidate}) is already answering on "
+                    f"{AGENT_SOCKET} — treating this as Gateway's own "
+                    "restart and NOT launching a second instance")
+    else:
+        detected_via = "restarter_log"
 
     mtime = _install4j_restarter_mtime()
-    if mtime is not None and mtime == _LAST_ADOPTED_RESTART_MTIME:
+    if (detected_via == "restarter_log" and mtime is not None
+            and mtime == _LAST_ADOPTED_RESTART_MTIME):
         # Same restart we already handled: the adopted JVM came up and
         # then died inside the 120s freshness window. That's a failure
         # of the restarted instance, not a restart in progress — go
@@ -3096,17 +3146,19 @@ def _adopt_self_restarted_gateway(reason, *, exit_code=None):
                  "failure, not another self-restart")
         return False
 
-    log.info(f"AUTORESTART: install4j restarter ran {age:.0f}s ago "
-             f"({_install4j_restarter_log_path()})")
-    log.warning(f"AUTORESTART: Gateway is restarting itself — NOT launching "
-                f"a second instance (old pid={old_pid}); waiting up to "
-                f"{_AUTO_RESTART_ADOPT_TIMEOUT_SECONDS}s for the new JVM's "
-                f"agent on {AGENT_SOCKET}")
-    _LAST_ADOPTED_RESTART_MTIME = mtime
+    if detected_via == "restarter_log":
+        log.info(f"AUTORESTART: install4j restarter ran {age:.0f}s ago "
+                 f"({_install4j_restarter_log_path()})")
+        log.warning(f"AUTORESTART: Gateway is restarting itself — NOT "
+                    f"launching a second instance (old pid={old_pid}); "
+                    f"waiting up to {_AUTO_RESTART_ADOPT_TIMEOUT_SECONDS}s "
+                    f"for the new JVM's agent on {AGENT_SOCKET}")
+        _LAST_ADOPTED_RESTART_MTIME = mtime
     t0 = time.monotonic()
 
     def _alert(level, status, new_pid, why):
         level(f"ALERT_AUTO_RESTART mode={TRADING_MODE} status={status} "
+              f"detected_via={detected_via} "
               f"old_pid={old_pid} new_pid={new_pid} "
               f"elapsed_seconds={time.monotonic() - t0:.0f} "
               f"reason=\"{why}\"")
@@ -3119,9 +3171,12 @@ def _adopt_self_restarted_gateway(reason, *, exit_code=None):
     tried = set()
     adopt_deadline = time.monotonic() + _AUTO_RESTART_ADOPT_TIMEOUT_SECONDS
     while True:
-        wait_budget = max(1.0, adopt_deadline - time.monotonic())
-        new_pid = _wait_for_self_restarted_agent(
-            old_pid, wait_budget, exclude=tried)
+        if first_candidate is not None:
+            new_pid, first_candidate = first_candidate, None
+        else:
+            wait_budget = max(1.0, adopt_deadline - time.monotonic())
+            new_pid = _wait_for_self_restarted_agent(
+                old_pid, wait_budget, exclude=tried)
         if new_pid is None or new_pid in tried:
             _alert(log.warning, "failed_no_agent", "none",
                    f"no new Gateway JVM answered on {AGENT_SOCKET} within "

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -3019,6 +3019,49 @@ def _install4j_restarter_log_path():
                         "restarter.log")
 
 
+# install4j's restarter is itself a JVM launched from the same
+# i4jruntime.jar Gateway uses, and it inherits INSTALL4J_ADD_VM_PARAMS
+# from the JVM that spawned it — so it loads OUR agent and binds OUR
+# socket for the couple of seconds it lives, answering GET_PID with its
+# own PID. Verified 2026-09-06 against the real binary: the restarter
+# logged "[gateway-input-agent] listening on <socket>" and reported its
+# own pid. Adopting it as if it were Gateway would mean monitoring a
+# process that exits immediately.
+#
+# The discriminator is -Dinstall4j.alternativeLogfile, which the
+# restarter sets to point at its own log and Gateway's JVM does not
+# carry (confirmed against both live Gateway JVMs in a running
+# container). i4jruntime.jar is NOT a discriminator — Gateway's own
+# cmdline contains it too.
+_INSTALL4J_RESTARTER_MARKER = "install4j.alternativeLogfile"
+
+
+def _cmdline_is_install4j_restarter(cmdline):
+    """True if this process cmdline is install4j's restarter JVM rather
+    than Gateway itself. ``cmdline`` is the NUL-joined /proc cmdline."""
+    if not cmdline:
+        return False
+    return _INSTALL4J_RESTARTER_MARKER in cmdline
+
+
+def _process_cmdline(pid):
+    """Return a process's cmdline as a space-joined string, or ``None``
+    where /proc is unavailable (macOS) or the process is gone."""
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as f:
+            raw = f.read()
+    except (OSError, ValueError):
+        return None
+    return raw.replace(b"\x00", b" ").decode("utf-8", errors="replace")
+
+
+def _is_install4j_restarter_pid(pid):
+    """True only when we can positively identify ``pid`` as install4j's
+    restarter. Unknown (no /proc) reads as False so behaviour off Linux
+    is unchanged — the adoption retry still covers it."""
+    return _cmdline_is_install4j_restarter(_process_cmdline(pid))
+
+
 def _install4j_restarter_mtime():
     """mtime of install4j's ``restarter.log``, or ``None`` if unreadable."""
     path = _install4j_restarter_log_path()
@@ -3055,13 +3098,20 @@ def _install4j_restarter_age(now=None):
     return max(age, 0.0)
 
 
-def _wait_for_self_restarted_agent(old_pid, timeout, exclude=()):
+def _wait_for_self_restarted_agent(old_pid, timeout, exclude=(),
+                                   seen_restarter=None):
     """Poll the agent socket until a JVM with a PID other than ``old_pid``
     (and not in ``exclude``) answers ``GET_PID``. Returns the new PID, or
     ``None`` on timeout.
 
     ``exclude`` carries PIDs already tried and found dead, so a second
     attempt doesn't re-adopt a transient JVM from the restarter chain.
+
+    install4j's restarter answers on this socket too (it inherits the
+    ``-javaagent`` and binds it for the seconds it lives). It is skipped
+    rather than adopted, and its PID is appended to ``seen_restarter``
+    if a list is passed — seeing it at all is conclusive evidence that
+    Gateway is restarting itself.
 
     The self-restarted JVM inherits ``INSTALL4J_ADD_VM_PARAMS`` through
     the restarter, so it loads the same ``-javaagent`` with the same
@@ -3076,7 +3126,15 @@ def _wait_for_self_restarted_agent(old_pid, timeout, exclude=()):
             pid = agent_get_pid()
             if (pid is not None and pid != old_pid and pid not in exclude
                     and pid > 1 and pid != os.getpid()):
-                return pid
+                if _is_install4j_restarter_pid(pid):
+                    if seen_restarter is not None and pid not in seen_restarter:
+                        seen_restarter.append(pid)
+                        log.info(f"AUTORESTART: install4j's restarter "
+                                 f"(pid={pid}) is holding the agent socket — "
+                                 "Gateway is definitely restarting itself; "
+                                 "waiting for the Gateway JVM it launches")
+                else:
+                    return pid
         time.sleep(0.5)
     return None
 
@@ -3110,6 +3168,7 @@ def _adopt_self_restarted_gateway(reason, *, exit_code=None):
             age = _install4j_restarter_age()
 
     first_candidate = None
+    seen_restarter = []
     if age is None:
         # No usable restarter.log. On a crash, stop here — that is a
         # genuine failure and the relaunch path owns it.
@@ -3123,14 +3182,17 @@ def _adopt_self_restarted_gateway(reason, *, exit_code=None):
                  f"{AGENT_SOCKET} for up to {_AUTO_RESTART_PROBE_SECONDS}s "
                  "in case Gateway restarted itself anyway")
         first_candidate = _wait_for_self_restarted_agent(
-            old_pid, _AUTO_RESTART_PROBE_SECONDS)
-        if first_candidate is None:
+            old_pid, _AUTO_RESTART_PROBE_SECONDS,
+            seen_restarter=seen_restarter)
+        if first_candidate is None and not seen_restarter:
             return False
-        detected_via = "agent_socket"
-        log.warning(f"AUTORESTART: a Gateway JVM we did not spawn "
-                    f"(pid={first_candidate}) is already answering on "
-                    f"{AGENT_SOCKET} — treating this as Gateway's own "
-                    "restart and NOT launching a second instance")
+        detected_via = ("install4j_restarter" if seen_restarter
+                        else "agent_socket")
+        who = ("install4j's restarter" if seen_restarter
+               else "a Gateway JVM we did not spawn")
+        log.warning(f"AUTORESTART: {who} is on {AGENT_SOCKET} — treating "
+                    "this as Gateway's own restart and NOT launching a "
+                    "second instance")
     else:
         detected_via = "restarter_log"
 
@@ -3176,7 +3238,8 @@ def _adopt_self_restarted_gateway(reason, *, exit_code=None):
         else:
             wait_budget = max(1.0, adopt_deadline - time.monotonic())
             new_pid = _wait_for_self_restarted_agent(
-                old_pid, wait_budget, exclude=tried)
+                old_pid, wait_budget, exclude=tried,
+                seen_restarter=seen_restarter)
         if new_pid is None or new_pid in tried:
             _alert(log.warning, "failed_no_agent", "none",
                    f"no new Gateway JVM answered on {AGENT_SOCKET} within "

--- a/tests/integration/gateway_autorestart_drill.py
+++ b/tests/integration/gateway_autorestart_drill.py
@@ -1,0 +1,245 @@
+"""Real-Gateway restart drill for the issue #23 adoption path.
+
+Launches the REAL IB Gateway JVM through the REAL install4j launcher with
+the REAL input agent, invokes the REAL .install4j/restarter with the
+environment Gateway itself carries, and runs the controller's recovery
+path against whatever comes up.
+
+This is the integration counterpart to the mocked unit tests in
+tests/test_pure_logic.py and the process-level tests in
+tests/test_core_logic.py. Those substitute Gateway; this one doesn't.
+
+**No credentials are supplied and nothing authenticates against IBKR**,
+so no session slot is touched and there is no CCP-lockout exposure. The
+replacement Gateway therefore sits at its login dialog and never opens
+its API port, so the one fact the drill stands in for is the API port
+being open -- i.e. Gateway carrying the session across its own restart,
+which is IBKR behaviour the controller neither causes nor changes.
+
+Not part of `make test`: it needs a Gateway installation, an X display
+and ~2 minutes. Run it inside a throwaway container built from the
+release image, never against a container holding a live session:
+
+    docker run -d --name ibg-drill --entrypoint sleep \
+      -v "$PWD":/repo:ro ghcr.io/<owner>/ibg-controller:<tag> 3600
+    docker exec -d ibg-drill sh -c 'Xvfb :1 -screen 0 1024x768x24 &'
+    docker exec -e DISPLAY=:1 -e TRADING_MODE=paper \
+      -e TWS_SETTINGS_PATH=/home/ibgateway/Jts_paper \
+      -e GATEWAY_INPUT_AGENT_SOCKET=/tmp/gateway-input-paper.sock \
+      -e CONTROLLER_READY_FILE=/tmp/gateway_ready_paper \
+      ibg-drill python3 /repo/tests/integration/gateway_autorestart_drill.py
+
+Observed 2026-09-07 against Gateway 10.45.1g, 17/17 checks: the
+restarter inherits INSTALL4J_ADD_VM_PARAMS and loads the agent, it holds
+the agent socket for ~1s between the old JVM dying and the replacement
+binding it, and the controller adopts the replacement (a JVM it never
+spawned) in 0.5s without launching a second Gateway.
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import time
+from unittest.mock import patch
+
+os.environ.setdefault("TRADING_MODE", "paper")
+_REPO = os.environ.get("IBG_REPO", "/repo")
+spec = importlib.util.spec_from_file_location(
+    "gateway_controller", os.path.join(_REPO, "gateway_controller.py"))
+gc = importlib.util.module_from_spec(spec)
+sys.modules["gateway_controller"] = gc
+spec.loader.exec_module(gc)
+
+RESULTS = []
+
+
+def check(name, ok, detail=""):
+    RESULTS.append((name, ok))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""),
+          flush=True)
+
+
+def java_pids():
+    out = []
+    for p in os.listdir("/proc"):
+        if not p.isdigit():
+            continue
+        cl = gc._process_cmdline(int(p)) or ""
+        if "/bin/java" in cl and "jts" in cl.lower():
+            out.append(int(p))
+    return out
+
+
+def main():
+    install = os.path.dirname(gc.find_gateway_launcher())
+    restarter = os.path.join(install, ".install4j", "restarter")
+    log_path = os.path.join(install, ".install4j", "restarter.log")
+    print(f"install dir : {install}")
+    print(f"restarter   : {restarter} (exists={os.path.exists(restarter)})")
+    try:
+        os.unlink(log_path)
+    except FileNotFoundError:
+        pass
+
+    print("\n--- launching the real Gateway JVM ---", flush=True)
+    gc.GATEWAY_PROC = gc.launch_gateway()
+    launcher_pid = gc.GATEWAY_PROC.pid
+    if not gc.agent_wait_ready(timeout=120):
+        print("FATAL: agent never came up")
+        return 2
+    gc.JVM_PID = gc.agent_get_pid()
+    old_pid = gc.JVM_PID
+    print(f"launcher pid={launcher_pid}  agent-reported JVM pid={old_pid}")
+    print(f"java procs before: {java_pids()}")
+    cl = gc._process_cmdline(old_pid) or ""
+    check("real Gateway JVM loaded our agent",
+          "gateway-input-agent.jar" in cl)
+
+    # The premise the whole fix rests on: Gateway's own process
+    # environment carries INSTALL4J_ADD_VM_PARAMS, so the restarter it
+    # spawns inherits it, and so does the Gateway the restarter launches.
+    with open(f"/proc/{old_pid}/environ", "rb") as f:
+        raw_env = f.read()
+    gw_env = {}
+    for item in raw_env.split(b"\x00"):
+        if b"=" in item:
+            k, v = item.split(b"=", 1)
+            gw_env[k.decode()] = v.decode("utf-8", "replace")
+    vm_params = gw_env.get("INSTALL4J_ADD_VM_PARAMS", "")
+    check("Gateway's own environ carries INSTALL4J_ADD_VM_PARAMS",
+          bool(vm_params))
+    check("...and it names our agent jar + socket",
+          "gateway-input-agent.jar" in vm_params and gc.AGENT_SOCKET in vm_params,
+          vm_params[:90])
+    check("real Gateway is NOT flagged as the restarter",
+          not gc._is_install4j_restarter_pid(old_pid))
+
+    # Gateway's own restart does two things: ask the calling launcher to
+    # shut down (via a shutdown-file property only Gateway's JVM sets),
+    # then re-execute the launcher. The drill supplies the first half
+    # directly and lets the real restarter do the second, so the sequence
+    # the controller observes is the production one: the old JVM exits,
+    # and a replacement it did not spawn comes up on the same socket.
+    print("\n--- invoking the REAL install4j restarter ---", flush=True)
+    launcher = gc.find_gateway_launcher()
+    r = subprocess.Popen(
+        [restarter, str(launcher_pid), launcher,
+         f"-VjtsConfigDir={gc.JTS_CONFIG_DIR}", "-VinstallerType=standalone"],
+        cwd=install, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        env=gw_env)                      # exactly Gateway's own environment
+    gc.GATEWAY_PROC.terminate()          # stands in for the shutdown file
+
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline and gc.GATEWAY_PROC.poll() is None:
+        time.sleep(0.2)
+    rc = gc.GATEWAY_PROC.poll()
+    print(f"old Gateway exit code: {rc}")
+    check("old Gateway is gone", rc is not None, f"rc={rc}")
+    # The socket does not sit idle: install4j's restarter binds it within
+    # a second of the old JVM dying, before the replacement Gateway takes
+    # it over. That is precisely the window the restarter discrimination
+    # exists for, and it is observed here rather than hypothesised.
+    check("the agent socket file survives the old JVM",
+          os.path.exists(gc.AGENT_SOCKET))
+
+    saw_restarter_on_socket = []
+    t0 = time.monotonic()
+    while time.monotonic() - t0 < 10:
+        try:
+            pid = gc.agent_get_pid()
+        except Exception:
+            pid = None
+        if pid and pid != old_pid and gc._is_install4j_restarter_pid(pid):
+            saw_restarter_on_socket.append(pid)
+            break
+        time.sleep(0.2)
+    print(f"restarter seen holding the agent socket: {saw_restarter_on_socket}")
+
+    print("\n--- controller recovery (the adoption path) ---", flush=True)
+    relaunches = []
+    # Without credentials the replacement Gateway sits at its login
+    # dialog and never opens the API port. In production it carries the
+    # session across and the port is already open, which is the branch
+    # under test, so stand in for that one fact and leave everything
+    # else real.
+    with patch.object(gc, "do_restart_in_place",
+                      side_effect=lambda: (relaunches.append(1), True)[1]), \
+         patch.object(gc, "is_api_port_open", lambda *a, **k: True), \
+         patch.object(gc, "_redrive_login",
+                      side_effect=AssertionError(
+                          "re-login must not run when the session is preserved")):
+        t1 = time.monotonic()
+        ok = gc._recover_jvm_or_escalate(
+            f"JVM exited with code {rc}", exit_code=0)
+        elapsed = time.monotonic() - t1
+
+    new_pid = gc.JVM_PID
+    print(f"recovery returned {ok} in {elapsed:.1f}s; JVM_PID {old_pid} -> {new_pid}")
+    print(f"restarter.log written: {os.path.exists(log_path)}")
+    if os.path.exists(log_path):
+        print("--- restarter.log ---")
+        print(open(log_path).read()[:600])
+
+    check("restarter.log landed where the code looks",
+          os.path.exists(log_path))
+    check("controller did NOT launch a second Gateway", not relaunches,
+          f"do_restart_in_place calls={len(relaunches)}")
+    check("adoption succeeded", bool(ok))
+    check("adopted a DIFFERENT JVM than the one that exited",
+          new_pid is not None and new_pid != old_pid,
+          f"{old_pid} -> {new_pid}")
+    check("GATEWAY_PROC is the adopted stand-in",
+          isinstance(gc.GATEWAY_PROC, gc._AdoptedProcess))
+    if isinstance(gc.GATEWAY_PROC, gc._AdoptedProcess):
+        check("adopted process reports alive",
+              gc.GATEWAY_PROC.poll() is None)
+    if new_pid:
+        ncl = gc._process_cmdline(new_pid) or ""
+        check("adopted process is Gateway, not the restarter",
+              "gateway-input-agent.jar" in ncl
+              and not gc._is_install4j_restarter_pid(new_pid))
+        check("adopted Gateway inherited our -javaagent",
+              "gateway-input-agent.jar" in ncl)
+
+    check("readiness re-signalled", os.path.exists(gc.READY_FILE))
+    live = java_pids()
+    classified = []
+    for p in live:
+        kind = ("restarter" if gc._is_install4j_restarter_pid(p)
+                else "gateway" if p == new_pid else "OTHER-GATEWAY")
+        classified.append(f"{p}={kind}")
+    print(f"java procs after: {classified}")
+    gateways = [p for p in live if not gc._is_install4j_restarter_pid(p)]
+    check("exactly one Gateway JVM (restarter aside) is running",
+          len(gateways) == 1 and gateways[0] == new_pid, str(classified))
+    # The restarter is short-lived; confirm it goes away on its own.
+    t = time.monotonic()
+    while time.monotonic() - t < 20:
+        leftover = [p for p in java_pids() if gc._is_install4j_restarter_pid(p)]
+        if not leftover:
+            break
+        time.sleep(0.5)
+    check("the restarter JVM exits on its own",
+          not [p for p in java_pids() if gc._is_install4j_restarter_pid(p)])
+    live = java_pids()
+
+    try:
+        r.wait(timeout=5)
+    except Exception:
+        r.kill()
+    out = r.stdout.read().decode("utf-8", "replace") if r.stdout else ""
+    print(f"--- restarter output ---\n{out[:400]}")
+
+    for p in live:
+        try:
+            os.kill(p, 9)
+        except Exception:
+            pass
+
+    passed = sum(1 for _, o in RESULTS if o)
+    print(f"\n{passed}/{len(RESULTS)} checks passed")
+    return 0 if passed == len(RESULTS) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -16,8 +16,9 @@ import sys
 import tempfile
 import threading
 import time
+import subprocess
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 def _load_module():
@@ -336,6 +337,246 @@ class TestDualModeEnvResolution(unittest.TestCase):
             self.assertIn("IBKR Gateway", gc.APP_NAME_CANDIDATES)
         elif gc.GATEWAY_OR_TWS == "tws":
             self.assertIn("Trader Workstation", gc.APP_NAME_CANDIDATES)
+
+
+# ── Issue #23: end-to-end auto-restart adoption ────────────────────────
+
+# A stand-in for a Gateway JVM carrying the input agent. Binds the
+# agent's Unix socket the way GatewayInputAgent does (deleteIfExists +
+# bind) and answers the part of the protocol the adoption path uses;
+# optionally opens a TCP port standing in for Gateway's API port. Run as
+# a real child process so the tests exercise real PIDs, real signals and
+# the real _AdoptedProcess rather than mocks.
+_FAKE_JVM = r"""
+import os, socket, sys, threading
+
+def serve(path, texts):
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(path); s.listen(8)
+    while True:
+        conn, _ = s.accept()
+        try:
+            buf = b""
+            while b"\n" not in buf:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+            cmd = buf.split(b"\n", 1)[0].decode("utf-8", "replace").strip().split(" ", 1)[0]
+            if cmd == "PING":
+                conn.sendall(b"OK pong\n")
+            elif cmd == "GET_PID":
+                conn.sendall(("OK %d\n" % os.getpid()).encode())
+            elif cmd == "LIST":
+                conn.sendall(("".join("text %s\n" % t for t in texts) + "END\n").encode())
+            elif cmd in ("WINDOWS", "LABELS"):
+                conn.sendall(b"END\n")
+            else:
+                conn.sendall(b"ERR unsupported\n")
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+args = [a for a in sys.argv[1:] if not a.startswith("--")]
+texts = ["Username", "Password"] if "--login-dialog" in sys.argv else []
+threading.Thread(target=serve, args=(args[0], texts), daemon=True).start()
+if len(args) > 1 and args[1] != "-":
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", int(args[1]))); srv.listen(8)
+    while True:
+        c, _ = srv.accept(); c.close()
+else:
+    threading.Event().wait()
+"""
+
+
+class TestAutoRestartAdoptionEndToEnd(unittest.TestCase):
+    """Issue #23 adoption driven end to end: real child processes, a real
+    Unix agent socket, a real TCP port, the real agent client and the
+    real _AdoptedProcess. Only Gateway itself is substituted.
+
+    The unit tests in test_pure_logic.py mock the collaborators, so they
+    can only prove the orchestration branches. These prove the mechanism:
+    that a JVM the controller never spawned can be found on the inherited
+    socket, adopted, and monitored — and that every failure path still
+    ends in the pre-issue-#23 relaunch.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.procs = []
+        self.addCleanup(self._kill_all)
+
+        install = os.path.join(self.tmp.name, "ibgateway", "10.45.1j")
+        os.makedirs(os.path.join(install, ".install4j"))
+        self.launcher = os.path.join(install, "ibgateway")
+        open(self.launcher, "w").close()
+        self.restarter_log = os.path.join(install, ".install4j", "restarter.log")
+        self.fake = os.path.join(self.tmp.name, "fake_jvm.py")
+        with open(self.fake, "w") as f:
+            f.write(_FAKE_JVM)
+        self.sock = os.path.join(self.tmp.name, "agent.sock")
+        self.ready = os.path.join(self.tmp.name, "ready")
+
+        probe = socket.socket()
+        probe.bind(("127.0.0.1", 0))
+        self.api_port = probe.getsockname()[1]
+        probe.close()
+
+        for p in (
+            patch.object(gc, "AGENT_SOCKET", self.sock),
+            patch.object(gc, "READY_FILE", self.ready),
+            patch.object(gc, "_GATEWAY_LAUNCHER_PATH", self.launcher),
+            patch.object(gc, "api_port_for_mode", lambda: self.api_port),
+            patch.object(gc, "_AUTO_RESTART_ADOPT_TIMEOUT_SECONDS", 15),
+            patch.object(gc, "_AUTO_RESTART_API_TIMEOUT_SECONDS", 15),
+            patch.object(gc, "_AUTO_RESTART_PROBE_SECONDS", 3),
+            patch.object(gc, "_AUTO_RESTART_DETECT_GRACE_SECONDS", 1),
+            patch.object(gc, "_is_ibkr_maintenance_window", lambda *a, **k: False),
+            patch.object(gc, "GATEWAY_PROC", None),
+            patch.object(gc, "JVM_PID", None),
+            patch.object(gc, "CURRENT_APP", None),
+            patch.object(gc, "_LAST_ADOPTED_RESTART_MTIME", None),
+        ):
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _kill_all(self):
+        for p in self.procs:
+            try:
+                p.kill()
+                p.wait(timeout=5)
+            except Exception:
+                pass
+
+    def _start_jvm(self, api=False, login_dialog=False):
+        args = [sys.executable, self.fake, self.sock,
+                str(self.api_port) if api else "-"]
+        if login_dialog:
+            args.append("--login-dialog")
+        p = subprocess.Popen(args)
+        self.procs.append(p)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if os.path.exists(self.sock) and gc.agent_wait_ready(timeout=1):
+                if gc.agent_get_pid() == p.pid:
+                    return p
+            time.sleep(0.1)
+        self.fail("fake JVM never answered on the agent socket")
+
+    def _running_then_killed(self):
+        """Bring up a JVM, register it as the controller's, then kill it —
+        i.e. what install4j's restarter does to the calling launcher."""
+        a = self._start_jvm()
+        gc.GATEWAY_PROC, gc.JVM_PID = a, a.pid
+        a.kill()
+        a.wait(timeout=10)
+        return a
+
+    def _write_restarter_log(self, age_seconds=0):
+        with open(self.restarter_log, "w") as f:
+            f.write("[INFO] ExecuteLauncherAction [ID 3018]: Launching x\n")
+        if age_seconds:
+            t = time.time() - age_seconds
+            os.utime(self.restarter_log, (t, t))
+
+    def _recover(self, exit_code=0):
+        """Real recovery entry point, with the relaunch path spied on."""
+        calls = []
+        with patch.object(gc, "do_restart_in_place",
+                          side_effect=lambda: (calls.append(1), True)[1]):
+            t0 = time.monotonic()
+            ok = gc._recover_jvm_or_escalate(
+                "JVM exited with code 0", exit_code=exit_code)
+        return ok, len(calls), time.monotonic() - t0
+
+    def test_adopts_the_self_restarted_jvm_and_never_launches_a_second(self):
+        self._running_then_killed()
+        self._write_restarter_log()
+        new = self._start_jvm(api=True)          # install4j's replacement
+
+        ok, relaunches, _ = self._recover()
+
+        self.assertTrue(ok)
+        self.assertEqual(relaunches, 0, "launched a second Gateway — issue #23")
+        self.assertIsInstance(gc.GATEWAY_PROC, gc._AdoptedProcess)
+        self.assertEqual(gc.GATEWAY_PROC.pid, new.pid)
+        self.assertEqual(gc.JVM_PID, new.pid)
+        self.assertIsNone(gc.GATEWAY_PROC.poll())
+        self.assertTrue(os.path.exists(self.ready))
+        self.assertIsNone(new.poll(), "adopted JVM was killed")
+
+    def test_adopts_via_the_socket_probe_when_no_restarter_log_exists(self):
+        # Verified 2026-09-06 against a real install: Gateway 10.45.1g's
+        # .install4j/restarter writes no restarter.log, while the issue
+        # #23 reporter's 10.45.1j box does. Detection must not depend on
+        # the log alone, or the fix silently never engages.
+        self._running_then_killed()
+        new = self._start_jvm(api=True)
+        self.assertFalse(os.path.exists(self.restarter_log))
+
+        ok, relaunches, _ = self._recover()
+
+        self.assertTrue(ok)
+        self.assertEqual(relaunches, 0)
+        self.assertEqual(gc.GATEWAY_PROC.pid, new.pid)
+
+    def test_genuine_crash_still_falls_through_to_the_relaunch(self):
+        self._running_then_killed()              # nothing comes back up
+
+        ok, relaunches, elapsed = self._recover()
+
+        self.assertTrue(ok)
+        self.assertEqual(relaunches, 1)
+        self.assertLess(elapsed, 12, "detection budget is not bounded")
+
+    def test_stale_restarter_log_does_not_trigger_adoption(self):
+        self._running_then_killed()
+        self._write_restarter_log(
+            age_seconds=gc._AUTO_RESTART_DETECT_WINDOW_SECONDS + 600)
+
+        _, relaunches, _ = self._recover()
+
+        self.assertEqual(relaunches, 1)
+
+    def test_adopted_jvm_dying_before_its_api_port_falls_through(self):
+        self._running_then_killed()
+        self._write_restarter_log()
+        dying = self._start_jvm(api=False)       # binds socket, no API port
+
+        killer = threading.Timer(1.0, dying.kill)
+        killer.start()
+        self.addCleanup(killer.cancel)
+        with patch.object(gc, "_AUTO_RESTART_API_TIMEOUT_SECONDS", 6), \
+             patch.object(gc, "_AUTO_RESTART_ADOPT_TIMEOUT_SECONDS", 4):
+            _, relaunches, elapsed = self._recover()
+        self.assertLess(elapsed, 20, "retry budget is not bounded")
+
+        self.assertEqual(relaunches, 1)
+        self.assertIsNotNone(dying.poll())
+
+    def test_the_same_restart_is_not_adopted_twice(self):
+        self._running_then_killed()
+        self._write_restarter_log()
+        new = self._start_jvm(api=True)
+        ok, _, _ = self._recover()
+        self.assertTrue(ok)
+
+        # The adopted instance now dies inside the log's freshness window.
+        new.kill()
+        new.wait(timeout=10)
+        _, relaunches, elapsed = self._recover(
+            exit_code=gc._EXIT_STATUS_UNOBSERVABLE)
+
+        self.assertEqual(relaunches, 1)
+        self.assertLess(elapsed, 12, "waited on an already-handled restart")
 
 
 if __name__ == "__main__":

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -514,10 +514,10 @@ class TestAutoRestartAdoptionEndToEnd(unittest.TestCase):
         self.assertIsNone(new.poll(), "adopted JVM was killed")
 
     def test_adopts_via_the_socket_probe_when_no_restarter_log_exists(self):
-        # Verified 2026-09-06 against a real install: Gateway 10.45.1g's
-        # .install4j/restarter writes no restarter.log, while the issue
-        # #23 reporter's 10.45.1j box does. Detection must not depend on
-        # the log alone, or the fix silently never engages.
+        # The restarter writes its log to a path relative to its working
+        # directory (-Dinstall4j.alternativeLogfile=./.install4j/...),
+        # so it is expected but not guaranteed to land where we look.
+        # Detection must not depend on the log alone.
         self._running_then_killed()
         new = self._start_jvm(api=True)
         self.assertFalse(os.path.exists(self.restarter_log))

--- a/tests/test_pure_logic.py
+++ b/tests/test_pure_logic.py
@@ -16,6 +16,12 @@ What's covered:
   - generate_totp: regression test against RFC 6238 SHA1 test vectors
     using a monkey-patched time.time()
   - api_port_for_mode: returns 4001 for live, 4002 for paper
+  - Issue #23 self-restart adoption: _install4j_restarter_age
+    (tempdir launcher layout), _AdoptedProcess (real throwaway child
+    processes; /proc-only cases skipped off Linux),
+    _adopt_self_restarted_gateway orchestration (collaborators
+    mocked), _recover_jvm_or_escalate ordering, attempt_reauth /
+    _redrive_login split
 
 What's NOT covered by this file (tracked separately):
   - jts.ini writer (side effects on filesystem — needs tempdir fixture)
@@ -24,7 +30,9 @@ What's NOT covered by this file (tracked separately):
 """
 
 import os
+import subprocess
 import sys
+import tempfile
 import time
 import unittest
 from unittest.mock import MagicMock, patch
@@ -2387,6 +2395,520 @@ class _capture_controller_errors:
         import logging
         logging.getLogger("controller").removeHandler(self.handler)
         return False
+
+
+# ── Issue #23: Gateway self-restart adoption ───────────────────────────
+
+def _sleeper():
+    """Spawn a throwaway child that idles until killed."""
+    return subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+
+
+class TestInstall4jRestarterAge(unittest.TestCase):
+    """_install4j_restarter_age is the only trigger for self-restart
+    detection: seconds since install4j last wrote
+    <launcher dir>/.install4j/restarter.log, or None when the file is
+    missing / stale / the launcher is unknown."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        d = os.path.join(self.tmp.name, "ibgateway", "10.45.1j")
+        os.makedirs(os.path.join(d, ".install4j"))
+        self.launcher = os.path.join(d, "ibgateway")
+        open(self.launcher, "w").close()
+        self.log_path = os.path.join(d, ".install4j", "restarter.log")
+        self._orig_launcher = gc._GATEWAY_LAUNCHER_PATH
+        gc._GATEWAY_LAUNCHER_PATH = self.launcher
+
+    def tearDown(self):
+        gc._GATEWAY_LAUNCHER_PATH = self._orig_launcher
+        self.tmp.cleanup()
+
+    def _write_log(self, age_seconds=0):
+        with open(self.log_path, "w") as f:
+            f.write("[INFO] Finished\n")
+        t = time.time() - age_seconds
+        os.utime(self.log_path, (t, t))
+
+    def test_log_path_sits_next_to_launcher(self):
+        self.assertEqual(gc._install4j_restarter_log_path(), self.log_path)
+
+    def test_missing_log_is_none(self):
+        self.assertIsNone(gc._install4j_restarter_age())
+
+    def test_fresh_log_reports_age(self):
+        self._write_log(age_seconds=3)
+        age = gc._install4j_restarter_age()
+        self.assertIsNotNone(age)
+        self.assertGreaterEqual(age, 0.0)
+        self.assertLess(age, 10.0)
+
+    def test_stale_log_is_none(self):
+        # Yesterday's restart (or a file left on a persistent volume)
+        # must not be mistaken for a restart in progress.
+        self._write_log(age_seconds=gc._AUTO_RESTART_DETECT_WINDOW_SECONDS + 60)
+        self.assertIsNone(gc._install4j_restarter_age())
+
+    def test_future_mtime_clamps_to_zero(self):
+        self._write_log(age_seconds=-30)
+        self.assertEqual(gc._install4j_restarter_age(), 0.0)
+
+    def test_far_future_log_is_none(self):
+        # Clock skew between the container and a persistent settings
+        # volume must not make every clean exit look like a restart.
+        self._write_log(age_seconds=-(gc._AUTO_RESTART_DETECT_WINDOW_SECONDS + 60))
+        self.assertIsNone(gc._install4j_restarter_age())
+
+    def test_unknown_launcher_is_none(self):
+        gc._GATEWAY_LAUNCHER_PATH = None
+        with patch.object(gc, "find_gateway_launcher", return_value=None):
+            self.assertIsNone(gc._install4j_restarter_log_path())
+            self.assertIsNone(gc._install4j_restarter_age())
+
+    def test_falls_back_to_launcher_discovery(self):
+        gc._GATEWAY_LAUNCHER_PATH = None
+        self._write_log()
+        with patch.object(gc, "find_gateway_launcher",
+                          return_value=self.launcher):
+            self.assertIsNotNone(gc._install4j_restarter_age())
+
+
+class TestAdoptedProcess(unittest.TestCase):
+    """_AdoptedProcess must look enough like subprocess.Popen for
+    monitor_loop, _teardown_jvm_for_restart, shutdown() and the health
+    snapshot: pid / poll() / returncode / terminate() / kill() / wait().
+    The exit status of a non-child is not observable, so a gone process
+    reports the _EXIT_STATUS_UNOBSERVABLE sentinel — never 0."""
+
+    def test_live_process_polls_none(self):
+        p = _sleeper()
+        try:
+            a = gc._AdoptedProcess(p.pid)
+            self.assertEqual(a.pid, p.pid)
+            self.assertIsNone(a.poll())
+            self.assertIsNone(a.returncode)
+        finally:
+            p.kill()
+            p.wait()
+
+    def test_terminate_then_wait_reports_unobservable_exit(self):
+        p = _sleeper()
+        a = gc._AdoptedProcess(p.pid)
+        a.terminate()
+        p.wait(timeout=10)  # reap so it's not a zombie on Linux
+        self.assertEqual(a.wait(timeout=5), gc._EXIT_STATUS_UNOBSERVABLE)
+        self.assertEqual(a.poll(), gc._EXIT_STATUS_UNOBSERVABLE)
+        self.assertIsNotNone(a.poll())
+        self.assertNotEqual(a.returncode, 0)
+
+    def test_wait_times_out_while_alive(self):
+        p = _sleeper()
+        try:
+            a = gc._AdoptedProcess(p.pid)
+            with self.assertRaises(subprocess.TimeoutExpired):
+                a.wait(timeout=0.3)
+        finally:
+            p.kill()
+            p.wait()
+
+    def test_kill_is_honoured(self):
+        p = _sleeper()
+        a = gc._AdoptedProcess(p.pid)
+        a.kill()
+        p.wait(timeout=10)
+        self.assertEqual(a.poll(), gc._EXIT_STATUS_UNOBSERVABLE)
+
+    def test_signals_are_withheld_when_identity_no_longer_matches(self):
+        # The adopted PID is not our child: between adoption and teardown
+        # the kernel can recycle it. Signalling then would kill an
+        # unrelated process.
+        p = _sleeper()
+        try:
+            a = gc._AdoptedProcess(p.pid)
+            with patch.object(gc._AdoptedProcess, "_alive", lambda self: False), \
+                 patch.object(gc.os, "kill") as kill:
+                a.terminate()
+                a.kill()
+                kill.assert_not_called()
+        finally:
+            p.kill()
+            p.wait()
+
+    def test_signals_to_gone_process_do_not_raise(self):
+        p = _sleeper()
+        pid = p.pid
+        p.kill()
+        p.wait()
+        a = gc._AdoptedProcess(pid)
+        a.terminate()
+        a.kill()
+        self.assertEqual(a.poll(), gc._EXIT_STATUS_UNOBSERVABLE)
+
+    @unittest.skipUnless(os.path.isdir("/proc"), "needs Linux /proc")
+    def test_unreaped_zombie_counts_as_exited(self):
+        # In the container the self-restarted JVM is reparented to
+        # run.sh; if its exit were ever left unreaped, os.kill(pid, 0)
+        # would still succeed on the zombie. /proc's state must win.
+        p = _sleeper()
+        a = gc._AdoptedProcess(p.pid)
+        p.kill()
+        time.sleep(0.5)  # dead but deliberately not yet reaped
+        try:
+            self.assertEqual(a.poll(), gc._EXIT_STATUS_UNOBSERVABLE)
+        finally:
+            p.wait()
+
+    @unittest.skipUnless(os.path.isdir("/proc"), "needs Linux /proc")
+    def test_proc_stat_parses_state_and_starttime(self):
+        stat = gc._proc_stat(os.getpid())
+        self.assertIsNotNone(stat)
+        state, starttime = stat
+        self.assertIn(state, ("R", "S", "D"))
+        self.assertIsInstance(starttime, int)
+
+    def test_proc_stat_missing_is_none(self):
+        self.assertIsNone(gc._proc_stat(2 ** 22 + 12345))
+
+
+class TestAdoptSelfRestartedGateway(unittest.TestCase):
+    """_adopt_self_restarted_gateway orchestration: only acts on a
+    fresh restarter.log, waits for the NEW JVM's agent, repoints the
+    globals before waiting on the API port, and reports True only when
+    the adopted Gateway is serving (port open, or login re-driven)."""
+
+    _GLOBALS = ("GATEWAY_PROC", "CURRENT_APP", "JVM_PID",
+                "_command_server_app",
+                "_AUTO_RESTART_ADOPT_TIMEOUT_SECONDS",
+                "_AUTO_RESTART_API_TIMEOUT_SECONDS",
+                "_AUTO_RESTART_DETECT_GRACE_SECONDS")
+
+    def setUp(self):
+        self._saved = {k: getattr(gc, k) for k in self._GLOBALS}
+        gc.GATEWAY_PROC = None
+        gc.CURRENT_APP = None
+        gc._command_server_app = None
+        gc.JVM_PID = 27
+        gc._AUTO_RESTART_ADOPT_TIMEOUT_SECONDS = 1
+        gc._AUTO_RESTART_API_TIMEOUT_SECONDS = 2
+        gc._AUTO_RESTART_DETECT_GRACE_SECONDS = 0
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(gc, k, v)
+
+    def _adopting(self, **overrides):
+        """Patch the collaborators for a successful adoption; override
+        individual ones per test."""
+        cfg = dict(
+            age=1.0, new_pid=5020, alive=True, port_open=True,
+            texts=set(), buttons=set(), redrive=True,
+        )
+        cfg.update(overrides)
+        stack = [
+            patch.object(gc, "_install4j_restarter_age", return_value=cfg["age"]),
+            patch.object(gc, "_wait_for_self_restarted_agent",
+                         return_value=cfg["new_pid"]),
+            patch.object(gc._AdoptedProcess, "_alive", return_value=cfg["alive"]),
+            patch.object(gc, "is_api_port_open", return_value=cfg["port_open"]),
+            patch.object(gc, "agent_list",
+                         return_value=(cfg["texts"], cfg["buttons"])),
+            patch.object(gc, "agent_windows", return_value=[]),
+            patch.object(gc, "agent_click", return_value=True),
+            patch.object(gc, "_redrive_login", return_value=cfg["redrive"]),
+            patch.object(gc, "signal_ready"),
+        ]
+        return stack
+
+    def _run(self, stack, exit_code=0):
+        mocks = {}
+        for p in stack:
+            m = p.start()
+            self.addCleanup(p.stop)
+            mocks[p.attribute] = m
+        result = gc._adopt_self_restarted_gateway("JVM exited with code 0",
+                                                   exit_code=exit_code)
+        return result, mocks
+
+    def test_not_a_self_restart_returns_false_untouched(self):
+        result, mocks = self._run(self._adopting(age=None))
+        self.assertFalse(result)
+        mocks["_wait_for_self_restarted_agent"].assert_not_called()
+        self.assertIsNone(gc.GATEWAY_PROC)
+        self.assertEqual(gc.JVM_PID, 27)
+
+    def test_grace_recheck_catches_restarter_write_after_exit(self):
+        # The restarter's first write can trail the code-0 exit by a
+        # couple of seconds; a short re-check window covers it.
+        gc._AUTO_RESTART_DETECT_GRACE_SECONDS = 3
+        ages = iter([None, None, 1.0])
+        stack = self._adopting()
+        stack[0] = patch.object(gc, "_install4j_restarter_age",
+                                side_effect=lambda: next(ages, 1.0))
+        result, mocks = self._run(stack)
+        self.assertTrue(result)
+        self.assertGreaterEqual(mocks["_install4j_restarter_age"].call_count, 3)
+
+    def test_no_grace_for_nonzero_exit(self):
+        # A crash (non-zero code) is not a self-restart candidate;
+        # don't spend the grace window on it.
+        gc._AUTO_RESTART_DETECT_GRACE_SECONDS = 3
+        result, mocks = self._run(self._adopting(age=None), exit_code=1)
+        self.assertFalse(result)
+        self.assertEqual(mocks["_install4j_restarter_age"].call_count, 1)
+
+    def test_no_new_agent_falls_through_without_adopting(self):
+        result, mocks = self._run(self._adopting(new_pid=None))
+        self.assertFalse(result)
+        self.assertIsNone(gc.GATEWAY_PROC)
+        self.assertEqual(gc.JVM_PID, 27)
+        mocks["signal_ready"].assert_not_called()
+
+    def test_adopts_when_api_port_opens(self):
+        result, mocks = self._run(self._adopting())
+        self.assertTrue(result)
+        self.assertIsInstance(gc.GATEWAY_PROC, gc._AdoptedProcess)
+        self.assertEqual(gc.GATEWAY_PROC.pid, 5020)
+        self.assertEqual(gc.JVM_PID, 5020)
+        self.assertEqual(gc.CURRENT_APP.get_process_id(), 5020)
+        self.assertIs(gc._command_server_app, gc.CURRENT_APP)
+        mocks["signal_ready"].assert_called_once()
+        mocks["_redrive_login"].assert_not_called()
+        wait = mocks["_wait_for_self_restarted_agent"]
+        wait.assert_called_once()
+        self.assertEqual(wait.call_args[0][0], 27)      # old pid
+        self.assertIn("exclude", wait.call_args[1])
+
+    def test_login_dialog_means_session_not_preserved_and_is_driven(self):
+        result, mocks = self._run(self._adopting(
+            port_open=False, texts={"Username", "Password"}))
+        self.assertTrue(result)
+        mocks["_redrive_login"].assert_called_once()
+        self.assertEqual(
+            mocks["_redrive_login"].call_args[0][0].get_process_id(), 5020)
+        # _redrive_login signals readiness itself; adoption must not
+        # double-signal.
+        mocks["signal_ready"].assert_not_called()
+
+    def test_login_failure_falls_through_with_proc_repointed(self):
+        result, mocks = self._run(self._adopting(
+            port_open=False, texts={"Username"}, redrive=False))
+        self.assertFalse(result)
+        # The adopted instance is left as GATEWAY_PROC so the fallback's
+        # teardown terminates it instead of no-op'ing on a dead Popen.
+        self.assertIsInstance(gc.GATEWAY_PROC, gc._AdoptedProcess)
+        self.assertEqual(gc.GATEWAY_PROC.pid, 5020)
+
+    def test_api_timeout_falls_through_with_proc_repointed(self):
+        result, mocks = self._run(self._adopting(port_open=False))
+        self.assertFalse(result)
+        self.assertIsInstance(gc.GATEWAY_PROC, gc._AdoptedProcess)
+        mocks["signal_ready"].assert_not_called()
+
+    def test_adopted_jvm_dying_falls_through(self):
+        result, mocks = self._run(self._adopting(alive=False, port_open=True))
+        self.assertFalse(result)
+        mocks["signal_ready"].assert_not_called()
+
+    def test_same_restarter_log_is_not_adopted_twice(self):
+        # The log stays "fresh" for 120s. An adopted JVM that dies inside
+        # that window is a failed restart, not a second self-restart —
+        # going through the adoption wait again just delays recovery.
+        saved = gc._LAST_ADOPTED_RESTART_MTIME
+        try:
+            stack = self._adopting()
+            stack.append(patch.object(gc, "_install4j_restarter_mtime",
+                                      return_value=1234.5))
+            gc._LAST_ADOPTED_RESTART_MTIME = 1234.5
+            result, mocks = self._run(stack)
+            self.assertFalse(result)
+            mocks["_wait_for_self_restarted_agent"].assert_not_called()
+        finally:
+            gc._LAST_ADOPTED_RESTART_MTIME = saved
+
+    def test_records_restarter_mtime_when_it_acts(self):
+        saved = gc._LAST_ADOPTED_RESTART_MTIME
+        try:
+            gc._LAST_ADOPTED_RESTART_MTIME = None
+            stack = self._adopting()
+            stack.append(patch.object(gc, "_install4j_restarter_mtime",
+                                      return_value=999.0))
+            result, _ = self._run(stack)
+            self.assertTrue(result)
+            self.assertEqual(gc._LAST_ADOPTED_RESTART_MTIME, 999.0)
+        finally:
+            gc._LAST_ADOPTED_RESTART_MTIME = saved
+
+    def test_retries_when_first_candidate_dies(self):
+        # install4j's restarter chain can briefly expose a JVM that isn't
+        # the replacement Gateway. Falling straight through to a relaunch
+        # on the first dead candidate would re-create the issue #23 race.
+        gc._AUTO_RESTART_ADOPT_TIMEOUT_SECONDS = 8
+        stack = self._adopting()
+        stack[1] = patch.object(gc, "_wait_for_self_restarted_agent",
+                                side_effect=[5020, 5021])
+        stack[2] = patch.object(gc._AdoptedProcess, "_alive",
+                                lambda self: self.pid != 5020)
+        result, mocks = self._run(stack)
+        self.assertTrue(result)
+        self.assertEqual(mocks["_wait_for_self_restarted_agent"].call_count, 2)
+        self.assertEqual(gc.JVM_PID, 5021)
+        # The dead candidate must not be offered again.
+        self.assertIn(5020, mocks["_wait_for_self_restarted_agent"]
+                      .call_args[1]["exclude"])
+
+    def test_maintenance_guard_applies_before_a_full_relogin(self):
+        # Adoption itself needs no auth, so it runs ahead of the v0.5.10
+        # guard — but this branch does re-auth, inside the window where
+        # IBKR's auth server is still draining.
+        stack = self._adopting(port_open=False, texts={"Username"})
+        stack.append(patch.object(gc, "_is_ibkr_maintenance_window",
+                                  return_value=True))
+        stack.append(patch.object(gc, "_apply_maintenance_recovery_delay"))
+        result, mocks = self._run(stack)
+        self.assertTrue(result)
+        mocks["_apply_maintenance_recovery_delay"].assert_called_once()
+        mocks["_redrive_login"].assert_called_once()
+
+    def test_disclaimers_dismissed_while_waiting(self):
+        opened = iter([False, True])
+        stack = self._adopting(buttons={"Accept"})
+        stack[3] = patch.object(gc, "is_api_port_open",
+                                side_effect=lambda *a, **k: next(opened, True))
+        with patch.object(gc, "SAFE_DISMISS_BUTTONS", ["Accept"]):
+            result, mocks = self._run(stack)
+        self.assertTrue(result)
+        mocks["agent_click"].assert_called_with("Accept")
+
+
+class TestRecoverAdoptsSelfRestartFirst(unittest.TestCase):
+    """_recover_jvm_or_escalate ordering for issue #23: adoption runs
+    before the maintenance-window guard and the fast restart, only when
+    the old JVM is gone and AUTO_RESTART_ADOPT is on; every adoption
+    failure falls through to the previous behaviour."""
+
+    def setUp(self):
+        self._saved = {k: getattr(gc, k) for k in
+                       ("GATEWAY_PROC", "_AUTO_RESTART_ADOPT")}
+        gc.GATEWAY_PROC = None
+        gc._AUTO_RESTART_ADOPT = True
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(gc, k, v)
+
+    def test_adoption_success_skips_relaunch(self):
+        with patch.object(gc, "_adopt_self_restarted_gateway",
+                          return_value=True) as adopt, \
+             patch.object(gc, "_is_ibkr_maintenance_window", return_value=True), \
+             patch.object(gc, "_apply_maintenance_recovery_delay") as delay, \
+             patch.object(gc, "do_restart_in_place") as restart, \
+             patch.object(gc, "_escalate_to_jvm_restart") as escalate:
+            self.assertTrue(gc._recover_jvm_or_escalate(
+                "JVM exited with code 0", exit_code=0))
+            adopt.assert_called_once_with("JVM exited with code 0", exit_code=0)
+            delay.assert_not_called()   # ordered BEFORE the 8-min guard
+            restart.assert_not_called()
+            escalate.assert_not_called()
+
+    def test_adoption_failure_falls_through_to_fast_restart(self):
+        with patch.object(gc, "_adopt_self_restarted_gateway",
+                          return_value=False), \
+             patch.object(gc, "_is_ibkr_maintenance_window", return_value=False), \
+             patch.object(gc, "do_restart_in_place", return_value=True) as restart, \
+             patch.object(gc, "_teardown_jvm_for_restart") as teardown:
+            self.assertTrue(gc._recover_jvm_or_escalate(
+                "JVM exited with code 0", exit_code=0))
+            restart.assert_called_once()
+            teardown.assert_not_called()  # nothing was adopted
+
+    def test_half_adopted_instance_is_torn_down_before_fallback(self):
+        adopted = MagicMock(spec=gc._AdoptedProcess)
+        adopted.pid = 5020
+        adopted.poll.return_value = None
+
+        def _adopt_but_fail(reason, *, exit_code=None):
+            gc.GATEWAY_PROC = adopted
+            return False
+
+        with patch.object(gc, "_adopt_self_restarted_gateway",
+                          side_effect=_adopt_but_fail), \
+             patch.object(gc, "_is_ibkr_maintenance_window", return_value=False), \
+             patch.object(gc, "do_restart_in_place", return_value=True) as restart, \
+             patch.object(gc, "_teardown_jvm_for_restart") as teardown:
+            self.assertTrue(gc._recover_jvm_or_escalate(
+                "JVM exited with code 0", exit_code=0))
+            teardown.assert_called_once()
+            restart.assert_called_once()
+
+    def test_adoption_exception_falls_through(self):
+        with patch.object(gc, "_adopt_self_restarted_gateway",
+                          side_effect=RuntimeError("boom")), \
+             patch.object(gc, "_is_ibkr_maintenance_window", return_value=False), \
+             patch.object(gc, "do_restart_in_place", return_value=True) as restart:
+            self.assertTrue(gc._recover_jvm_or_escalate(
+                "JVM exited with code 0", exit_code=0))
+            restart.assert_called_once()
+
+    def test_env_kill_switch_disables_adoption(self):
+        gc._AUTO_RESTART_ADOPT = False
+        with patch.object(gc, "_adopt_self_restarted_gateway") as adopt, \
+             patch.object(gc, "_is_ibkr_maintenance_window", return_value=False), \
+             patch.object(gc, "do_restart_in_place", return_value=True):
+            self.assertTrue(gc._recover_jvm_or_escalate(
+                "JVM exited with code 0", exit_code=0))
+            adopt.assert_not_called()
+
+    def test_alive_jvm_skips_adoption(self):
+        # "monitor_loop re-auth failed" arrives with the JVM still up;
+        # adoption only makes sense once the old JVM is gone.
+        gc.GATEWAY_PROC = MagicMock()
+        gc.GATEWAY_PROC.poll.return_value = None
+        with patch.object(gc, "_adopt_self_restarted_gateway") as adopt, \
+             patch.object(gc, "_is_ibkr_maintenance_window", return_value=False), \
+             patch.object(gc, "do_restart_in_place", return_value=True):
+            self.assertTrue(gc._recover_jvm_or_escalate("monitor_loop re-auth failed"))
+            adopt.assert_not_called()
+
+    def test_unobservable_exit_gets_maintenance_guard(self):
+        # An adopted JVM's exit code can't be observed; treat it like 0
+        # for the v0.5.10 guard (conservative). A real crash (non-zero)
+        # still bypasses the guard.
+        with patch.object(gc, "_adopt_self_restarted_gateway", return_value=False), \
+             patch.object(gc, "_is_ibkr_maintenance_window", return_value=True), \
+             patch.object(gc, "_apply_maintenance_recovery_delay") as delay, \
+             patch.object(gc, "do_restart_in_place", return_value=True):
+            gc._recover_jvm_or_escalate(
+                "adopted Gateway JVM exited",
+                exit_code=gc._EXIT_STATUS_UNOBSERVABLE)
+            delay.assert_called_once()
+            delay.reset_mock()
+            gc._recover_jvm_or_escalate("JVM exited with code 1", exit_code=1)
+            delay.assert_not_called()
+
+    def test_env_parse_defaults_on(self):
+        self.assertIs(gc._coerce_yes_no("yes") is not False, True)
+        self.assertIs(gc._coerce_yes_no("no") is not False, False)
+        # Unrecognised values must not silently disable the fix.
+        self.assertIs(gc._coerce_yes_no("banana") is not False, True)
+
+
+class TestAttemptReauthSplit(unittest.TestCase):
+    """attempt_reauth keeps its contract after the _redrive_login split:
+    no login dialog => True without driving anything; dialog => the
+    result of _redrive_login."""
+
+    def test_no_dialog_is_noop_true(self):
+        with patch.object(gc, "agent_list", return_value=(set(), set())), \
+             patch.object(gc, "_redrive_login") as redrive:
+            self.assertTrue(gc.attempt_reauth(None))
+            redrive.assert_not_called()
+
+    def test_dialog_delegates_to_redrive(self):
+        app = object()
+        with patch.object(gc, "agent_list", return_value=({"Username"}, set())), \
+             patch.object(gc, "_redrive_login", return_value=False) as redrive:
+            self.assertFalse(gc.attempt_reauth(app))
+            redrive.assert_called_once_with(app)
 
 
 if __name__ == "__main__":

--- a/tests/test_pure_logic.py
+++ b/tests/test_pure_logic.py
@@ -2483,6 +2483,61 @@ class TestInstall4jRestarterAge(unittest.TestCase):
             self.assertIsNotNone(gc._install4j_restarter_age())
 
 
+class TestInstall4jRestarterDiscrimination(unittest.TestCase):
+    """install4j's restarter is itself a JVM that inherits
+    INSTALL4J_ADD_VM_PARAMS, so it loads our agent and answers GET_PID
+    with its own PID for the seconds it lives. Adopting it would mean
+    monitoring a process that exits immediately. Both fixtures below are
+    real cmdlines captured 2026-09-06 — the restarter from running the
+    binary in a container off the release image, Gateway from the live
+    container's JVM."""
+
+    RESTARTER = (
+        "/usr/local/zulu17.60.17-ca-fx-jre17.0.16-linux_aarch64/bin/java "
+        "--add-opens java.desktop/java.awt=ALL-UNNAMED "
+        "-Dinstall4j.alternativeLogfile=./.install4j/restarter.log "
+        "-javaagent:/home/ibgateway/gateway-input-agent.jar=/tmp/probe.sock "
+        "-Djava.security.manager=allow -classpath "
+        "/home/ibgateway/Jts/ibgateway/10.45.1g/.install4j/i4jruntime.jar:"
+        "/home/ibgateway/Jts/ibgateway/10.45.1g/.install4j/launcher3257f6f9.jar "
+        "install4j.App1256852828Id640 640 11 /tmp/marker.sh ")
+
+    GATEWAY = (
+        "/usr/local/zulu17.60.17-ca-fx-jre17.0.16-linux_aarch64/bin/java "
+        "-splash:/home/ibgateway/Jts/ibgateway/10.45.1g/.install4j/s_clyey9.png "
+        "--add-opens=java.base/java.util=ALL-UNNAMED "
+        "-javaagent:/home/ibgateway/gateway-input-agent.jar="
+        "/tmp/gateway-input-live.sock -classpath "
+        "/home/ibgateway/Jts/ibgateway/10.45.1g/.install4j/i4jruntime.jar "
+        "-VjtsConfigDir=/home/ibgateway/Jts_live -VinstallerType=standalone ")
+
+    def test_identifies_the_restarter(self):
+        self.assertTrue(gc._cmdline_is_install4j_restarter(self.RESTARTER))
+
+    def test_does_not_mistake_gateway_for_the_restarter(self):
+        # Both carry i4jruntime.jar and our -javaagent, so neither is a
+        # usable discriminator; only the restarter's own log flag is.
+        self.assertFalse(gc._cmdline_is_install4j_restarter(self.GATEWAY))
+        self.assertIn("i4jruntime.jar", self.GATEWAY)
+        self.assertIn("gateway-input-agent.jar", self.GATEWAY)
+
+    def test_unknown_cmdline_is_not_the_restarter(self):
+        # No /proc (macOS) must read as "not the restarter", leaving the
+        # adoption retry to cover it rather than refusing to adopt.
+        self.assertFalse(gc._cmdline_is_install4j_restarter(None))
+        self.assertFalse(gc._cmdline_is_install4j_restarter(""))
+
+    def test_own_process_is_not_the_restarter(self):
+        self.assertFalse(gc._is_install4j_restarter_pid(os.getpid()))
+
+    def test_cmdline_of_a_missing_pid_is_none(self):
+        self.assertIsNone(gc._process_cmdline(2 ** 22 + 12345))
+
+    @unittest.skipUnless(os.path.isdir("/proc"), "needs Linux /proc")
+    def test_reads_a_real_cmdline(self):
+        self.assertIn("python", (gc._process_cmdline(os.getpid()) or "").lower())
+
+
 class TestAdoptedProcess(unittest.TestCase):
     """_AdoptedProcess must look enough like subprocess.Popen for
     monitor_loop, _teardown_jvm_for_restart, shutdown() and the health
@@ -2664,8 +2719,30 @@ class TestAdoptSelfRestartedGateway(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(gc.JVM_PID, 5020)
         # The probe result is reused; no second wait for the same JVM.
-        mocks["_wait_for_self_restarted_agent"].assert_called_once_with(27, 5)
+        wait = mocks["_wait_for_self_restarted_agent"]
+        wait.assert_called_once()
+        self.assertEqual(wait.call_args[0][:2], (27, 5))
         mocks["signal_ready"].assert_called_once()
+
+    def test_restarter_on_the_socket_counts_as_detection(self):
+        # The restarter answering our socket is conclusive evidence of a
+        # self-restart even with no usable restarter.log — but it must
+        # not itself be adopted; we wait for the Gateway JVM it launches.
+        gc._AUTO_RESTART_PROBE_SECONDS = 5
+        stack = self._adopting(age=None)
+
+        def wait(old, timeout, exclude=(), seen_restarter=None):
+            if seen_restarter is not None and not seen_restarter:
+                seen_restarter.append(99)      # restarter seen, no Gateway yet
+                return None
+            return 5020                         # Gateway's JVM arrives
+
+        stack[1] = patch.object(gc, "_wait_for_self_restarted_agent",
+                                side_effect=wait)
+        result, mocks = self._run(stack)
+        self.assertTrue(result)
+        self.assertEqual(gc.JVM_PID, 5020)
+        self.assertEqual(mocks["_wait_for_self_restarted_agent"].call_count, 2)
 
     def test_socket_probe_finding_nothing_falls_through(self):
         gc._AUTO_RESTART_PROBE_SECONDS = 5

--- a/tests/test_pure_logic.py
+++ b/tests/test_pure_logic.py
@@ -2038,6 +2038,16 @@ class TestRecoverJvmMaintenanceGuard(unittest.TestCase):
     recovery environment.
     """
 
+    def setUp(self):
+        # These test the v0.5.10 guard, not issue #23 adoption. Without
+        # this patch each one runs the real adoption path first and pays
+        # its full detection budget (grace + socket probe) on a host that
+        # has neither a restarter.log nor an agent socket.
+        p = patch.object(gc, "_adopt_self_restarted_gateway",
+                         return_value=False)
+        p.start()
+        self.addCleanup(p.stop)
+
     def test_code_0_in_window_calls_delay_before_restart(self):
         call_order = []
         with patch("gateway_controller._is_ibkr_maintenance_window",
@@ -2544,11 +2554,14 @@ class TestAdoptedProcess(unittest.TestCase):
         a.kill()
         self.assertEqual(a.poll(), gc._EXIT_STATUS_UNOBSERVABLE)
 
-    @unittest.skipUnless(os.path.isdir("/proc"), "needs Linux /proc")
     def test_unreaped_zombie_counts_as_exited(self):
         # In the container the self-restarted JVM is reparented to
         # run.sh; if its exit were ever left unreaped, os.kill(pid, 0)
-        # would still succeed on the zombie. /proc's state must win.
+        # would still succeed on the zombie. /proc's state must win —
+        # and where there is no /proc, the WNOHANG reap must. Without
+        # one of the two a dead JVM looks alive forever and teardown
+        # burns its whole SIGTERM grace on it (caught by the end-to-end
+        # adoption tests in test_core_logic.py).
         p = _sleeper()
         a = gc._AdoptedProcess(p.pid)
         p.kill()
@@ -2580,7 +2593,8 @@ class TestAdoptSelfRestartedGateway(unittest.TestCase):
                 "_command_server_app",
                 "_AUTO_RESTART_ADOPT_TIMEOUT_SECONDS",
                 "_AUTO_RESTART_API_TIMEOUT_SECONDS",
-                "_AUTO_RESTART_DETECT_GRACE_SECONDS")
+                "_AUTO_RESTART_DETECT_GRACE_SECONDS",
+                "_AUTO_RESTART_PROBE_SECONDS")
 
     def setUp(self):
         self._saved = {k: getattr(gc, k) for k in self._GLOBALS}
@@ -2591,6 +2605,9 @@ class TestAdoptSelfRestartedGateway(unittest.TestCase):
         gc._AUTO_RESTART_ADOPT_TIMEOUT_SECONDS = 1
         gc._AUTO_RESTART_API_TIMEOUT_SECONDS = 2
         gc._AUTO_RESTART_DETECT_GRACE_SECONDS = 0
+        # Off by default here so each test says explicitly whether it is
+        # exercising the restarter.log path or the socket-probe fallback.
+        gc._AUTO_RESTART_PROBE_SECONDS = 0
 
     def tearDown(self):
         for k, v in self._saved.items():
@@ -2630,11 +2647,40 @@ class TestAdoptSelfRestartedGateway(unittest.TestCase):
         return result, mocks
 
     def test_not_a_self_restart_returns_false_untouched(self):
+        # No restarter.log and the probe disabled: nothing to adopt.
         result, mocks = self._run(self._adopting(age=None))
         self.assertFalse(result)
         mocks["_wait_for_self_restarted_agent"].assert_not_called()
         self.assertIsNone(gc.GATEWAY_PROC)
         self.assertEqual(gc.JVM_PID, 27)
+
+    def test_socket_probe_adopts_when_no_restarter_log_is_written(self):
+        # Verified 2026-09-06 on Gateway 10.45.1g: the install4j restarter
+        # ships but writes no restarter.log. A live JVM answering our
+        # agent socket that we did not spawn is direct evidence of a
+        # self-restart, so adoption must not depend on the log alone.
+        gc._AUTO_RESTART_PROBE_SECONDS = 5
+        result, mocks = self._run(self._adopting(age=None))
+        self.assertTrue(result)
+        self.assertEqual(gc.JVM_PID, 5020)
+        # The probe result is reused; no second wait for the same JVM.
+        mocks["_wait_for_self_restarted_agent"].assert_called_once_with(27, 5)
+        mocks["signal_ready"].assert_called_once()
+
+    def test_socket_probe_finding_nothing_falls_through(self):
+        gc._AUTO_RESTART_PROBE_SECONDS = 5
+        result, _ = self._run(self._adopting(age=None, new_pid=None))
+        self.assertFalse(result)
+        self.assertIsNone(gc.GATEWAY_PROC)
+        self.assertEqual(gc.JVM_PID, 27)
+
+    def test_socket_probe_skipped_on_a_crash(self):
+        # A non-zero exit is a crash, not a self-restart: the relaunch
+        # path owns it and must not be delayed by the probe.
+        gc._AUTO_RESTART_PROBE_SECONDS = 5
+        result, mocks = self._run(self._adopting(age=None), exit_code=1)
+        self.assertFalse(result)
+        mocks["_wait_for_self_restarted_agent"].assert_not_called()
 
     def test_grace_recheck_catches_restarter_write_after_exit(self):
         # The restarter's first write can trail the code-0 exit by a


### PR DESCRIPTION
Fixes #23.

With `AUTO_RESTART_TIME` set, Gateway restarts **itself**: the JVM spawns install4j's `.install4j/restarter`, which shuts the calling launcher down and re-executes it, and the replacement re-uses the session credentials, so no login and no second factor. `monitor_loop` read that code-0 exit as a crash and `do_restart_in_place` launched a **second** Gateway about two seconds before install4j launched its own. Two instances on one X display and one settings dir, the agent drove the wrong window, login failed, the controller halted, and the container's restart policy brought it back as a cold login with a fresh IB Key push. @maciejlaska measured 23 container restarts and 1-2 h without a session per night over five days; an otherwise identical paper container with no auto-restart time ran 13 days clean.

## What changes

- **Detect the self-restart, adopt the instance install4j is bringing up, launch nothing.** The replacement inherits `INSTALL4J_ADD_VM_PARAMS` through the restarter, so its agent binds the same socket and reports its PID. It becomes `GATEWAY_PROC` through a `Popen`-shaped stand-in (`_AdoptedProcess`) that uses `os.kill(pid, 0)`, a `WNOHANG` reap, and `/proc` for zombie and PID-reuse detection.
- **Three detection signals**, reported as `detected_via=`: a fresh `restarter.log`; a live Gateway JVM we never spawned answering the agent socket after a clean exit; or install4j's restarter itself holding that socket. Never a wall-clock comparison against `AUTO_RESTART_TIME`, whose timezone the controller cannot know.
- **Session not preserved** (a login dialog appears, e.g. the weekly full re-auth): the existing re-auth pipeline runs on the adopted JVM, with the v0.5.10 maintenance-window guard applied to that branch.
- **Fail-safes** all fall through to today's `do_restart_in_place`, tearing down a half-adopted instance first. `AUTO_RESTART_ADOPT=no` disables the whole path.
- New token `ALERT_AUTO_RESTART` (`status=adopted` or four `failed_*` values). New vars `AUTO_RESTART_ADOPT`, `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`, `AUTO_RESTART_PROBE_SECONDS`.

## Validation

314 unit tests, plus `tests/integration/gateway_autorestart_drill.py`, which launches the real Gateway through the real install4j launcher and invokes the real `.install4j/restarter` with the environment Gateway itself carries. 17/17 against Gateway 10.45.1g. It uses no credentials and never authenticates, so no IBKR session slot is touched. Observed there:

- Gateway's own environment carries `INSTALL4J_ADD_VM_PARAMS` naming the agent jar and socket, so the restarter inherits it and loads the agent.
- The restarter holds the agent socket for about a second between the old JVM dying and the replacement binding it. The controller identifies it by `-Dinstall4j.alternativeLogfile`, which Gateway's own JVM does not carry, and skips it.
- The controller adopted the replacement 0.5 s after the exit, never called `do_restart_in_place`, left exactly one Gateway running, and re-signalled readiness.

The drill caught two defects the mocked tests passed clean: a dead adopted JVM reporting alive where `/proc` is absent or an exit is unreaped, and adoption latching onto the restarter.

**Still asserted rather than observed:** that Gateway carries the session across its own restart. Without credentials the replacement sits at its login dialog and never opens its API port, so the drill stands in for that one fact. It is IBKR behaviour the controller neither causes nor changes.

## How to test this

No release image is published for this branch on purpose: a `v*` tag would cut a GitHub release and move `:latest`. Build it instead:

```sh
git clone -b fix/issue-23-adopt-gateway-self-restart https://github.com/code-hustler-ft3d/ibg-controller
cd ibg-controller
make                     # needs a JDK 17+, only for the agent jar
docker build -t ibg-controller:issue23 .
```

Then run it in place of your current image with `AUTO_RESTART_TIME` unchanged. On the night of the restart, expect:

```
AUTORESTART: install4j restarter ran 0s ago (...)
AUTORESTART: Gateway is restarting itself — NOT launching a second instance (old pid=...)
AUTORESTART: adopted Gateway pid=... (was ...) after 0s
ALERT_AUTO_RESTART mode=live status=adopted detected_via=restarter_log ... reason="API port 4001 open — session preserved ..."
```

A `status=failed_*` line means it fell back to the old relaunch for that night; the `AUTORESTART:` lines above it say why. `AUTO_RESTART_ADOPT=no` restores the previous behaviour if anything misbehaves.
