### PR TITLE
ci: cover upstream's latest Gateway line; document building on any base (refs #24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,21 @@ jobs:
     # upstream tags so we catch breakage from an upstream layout change
     # (JRE path, apt package rename, userid shift) before users do.
     #
-    # The matrix covers the two Gateway versions we actively verify
-    # against — the previously shipped pin (10.45.1c) and the current
-    # stable now pinned in release-image.yml (10.45.1g). Add a new entry
-    # here when bumping verified versions in README.md / docs/FROM_IBC.md.
+    # The matrix covers the Gateway versions we verify against: two
+    # earlier pins (10.45.1c, 10.45.1g), the current stable pinned in
+    # release-image.yml (10.45.1j), and the head of upstream's `latest`
+    # channel (10.50.1e), which is a different Gateway minor. Add a new
+    # entry here when bumping verified versions in README.md /
+    # docs/FROM_IBC.md.
+    #
+    # Version tags, never the floating `:stable` / `:latest`, so a PR
+    # run stays deterministic and upstream moving a channel can't turn
+    # an unrelated PR red.
+    #
+    # The `latest`-channel entry answers "does the image still build and
+    # boot on the newer Gateway line" (issue #24) — it is a build and
+    # smoke check only. Login, 2FA and the dialog handlers are verified
+    # against 10.45.x; nothing here claims they are verified on 10.50.
     strategy:
       fail-fast: false
       matrix:
@@ -153,6 +164,7 @@ jobs:
           - ghcr.io/gnzsnz/ib-gateway:10.45.1c
           - ghcr.io/gnzsnz/ib-gateway:10.45.1g
           - ghcr.io/gnzsnz/ib-gateway:10.45.1j
+          - ghcr.io/gnzsnz/ib-gateway:10.50.1e
     steps:
       - name: Check out
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ and the project follows [Semantic Versioning](https://semver.org/).
   `release-image.yml` comment describing arm64 as Zulu-based is
   corrected.
 - CI matrix gains 10.45.1j.
+- **CI now builds against upstream's `latest` channel as well (issue
+  #24).** The `gateway-version-matrix` job gains
+  `ghcr.io/gnzsnz/ib-gateway:10.50.1e`, so a layout change on the newer
+  Gateway line surfaces here rather than in someone's build. Build and
+  boot only — login, 2FA and the dialog handlers are verified against
+  10.45.x, and nothing here claims otherwise. Version tags, never the
+  floating `:stable` / `:latest`, so PR runs stay deterministic.
+- The `Dockerfile` header and `docs/FROM_IBC.md` document building
+  against any gnzsnz base, including the `latest` channel, via
+  `--build-arg UPSTREAM_IMAGE=`. No repo change is needed to do this;
+  the recipe was simply undocumented.
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,18 @@
 #   docker build -t ibg-controller:local \
 #     --build-arg UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1c@sha256:... .
 #
+# Any gnzsnz base works, including their `latest` channel if you want a
+# newer Gateway than the stable line carries (issue #24). This layer is
+# three apt packages and four COPYs, so it is a pull plus about a
+# minute, not a rebuild of the upstream image:
+#
+#   docker build -t ibg-controller:edge \
+#     --build-arg UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:latest \
+#     --build-arg IB_GATEWAY_VERSION=10.50.1e .
+#
+# CI builds against that line too, but only as a build-and-boot check —
+# the login, 2FA and dialog paths are verified against 10.45.x.
+#
 # Build prerequisites: run `make` in the repo root first to populate
 # dist/ with the agent jar and the controller .py, then `docker build .`
 # from the same directory.

--- a/docs/FROM_IBC.md
+++ b/docs/FROM_IBC.md
@@ -170,6 +170,20 @@ The shipped `Dockerfile` extends `ghcr.io/gnzsnz/ib-gateway:stable`.
 For reproducible builds, pin to a digest via `--build-arg
 UPSTREAM_IMAGE=...@sha256:...`.
 
+Any gnzsnz base works. To build against their `latest` channel instead
+of `stable` — a newer Gateway line, e.g. for the in-app browser the
+passkey flow uses:
+
+```bash
+docker build -t ibg-controller:edge \
+  --build-arg UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:latest \
+  --build-arg IB_GATEWAY_VERSION=10.50.1e .
+```
+
+CI covers that line as a build-and-boot check. The login, 2FA and
+dialog handlers are verified against 10.45.x only, so treat a
+`latest`-based image as unverified for those paths.
+
 ### 2. Convert your IBC config
 
 ```bash


### PR DESCRIPTION
Addresses #24.

**The request:** a published ibg-controller image built on gnzsnz's `latest` channel, so experimenting doesn't require a local build.

**What I checked first.** Two of the premises don't hold:

- **No published gnzsnz image carries the jxbrowser libraries**, on either channel. Straight from the registry: `:latest` (10.50.1e, built 2026-08-26) and `:stable` (10.45.1j, 2026-08-06) both ship the identical eight-package apt line (`gettext-base socat xvfb x11vnc sshpass openssh-client sudo telnet`) and none of the libraries from upstream PR gnzsnz/ib-gateway-docker#440. That PR merged 2026-08-29, after the last `latest` build, into the shared `Dockerfile.template`, which is rendered into *both* channels on each one's next IBKR bump. So the libraries aren't a `:latest` property, and the next stable build gets them too. What differs between the lines is Gateway 10.50 vs 10.45.
- **Release images are already digest-pinned** (`ghcr.io/gnzsnz/ib-gateway:10.45.1g@sha256:827d7a5b…`), since v0.5.8 / #15. The `:stable` reference is only the Dockerfile's `ARG` default for local builds, so published images can't break when the stable line moves.

And building on another base already needs no repo change: this layer is three apt packages and four `COPY`s on whatever base `UPSTREAM_IMAGE` names, so it's a pull plus about a minute, not a rebuild of the gnzsnz image.

**What was actually missing**, and is added here:

- `gateway-version-matrix` gains `ghcr.io/gnzsnz/ib-gateway:10.50.1e`, so a layout change on the newer Gateway line surfaces in CI instead of in someone's build. Build and boot only — login, 2FA and the dialog handlers are verified against 10.45.x, and the comment says so. Version tags rather than the floating channels, so PR runs stay deterministic.
- The `Dockerfile` header and `docs/FROM_IBC.md` document the `--build-arg UPSTREAM_IMAGE=` recipe for the latest channel. It always worked; it was just undocumented.

**Deliberately not added: a published `:edge` tag.** The workflow diff is small, but the cost is recurring — a second digest bumped by hand on a line that moved nine times in two months, a second signature, SBOM and verification recipe per release, and a tag whose 2FA paths would be unverified. If it turns out the passkey browser needs Gateway 10.50 specifically rather than 10.45 plus the #440 libraries, that changes the calculation; nobody has tested that combination yet.

**Also worth doing separately:** the stable pin is three patch releases behind (10.45.1g → 10.45.1j). Upstream changed the arm64 build path at 10.45.1h to IBKR's native linux-arm installer, so that bump wants its own PR and a live check rather than riding along here.