### PR TITLE
chore(image): bump upstream Gateway pin 10.45.1g → 10.45.1j

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
         upstream:
           - ghcr.io/gnzsnz/ib-gateway:10.45.1c
           - ghcr.io/gnzsnz/ib-gateway:10.45.1g
+          - ghcr.io/gnzsnz/ib-gateway:10.45.1j
     steps:
       - name: Check out
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -13,8 +13,10 @@ name: Release image
 #     default GITHUB_TOKEN.
 #   - The `platforms` list below controls architectures. We publish
 #     linux/amd64 + linux/arm64: upstream gnzsnz/ib-gateway ships both
-#     (amd64 uses install4j JRE, arm64 uses Zulu), and the Dockerfile's
-#     ATK bridge step handles both JRE layouts. Keep this list in sync
+#     (both now use install4j's own JRE registry; arm64 used a separate
+#     Zulu JRE only before 10.45.1h, when upstream switched aarch64 to
+#     IBKR's native arm installer in gnzsnz/ib-gateway-docker#397), and
+#     the Dockerfile's ATK bridge step handles both layouts. Keep in sync
 #     with `docker-compose` consumers that pin --platform.
 #   - If you rename the workflow file, update docs/SECURITY.md's
 #     cosign verification example — the `--certificate-identity`
@@ -143,8 +145,8 @@ jobs:
           # image label — keep it in lockstep with the digest pin above so a
           # `docker inspect` reports the exact bundled Gateway build.
           build-args: |
-            UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1g@sha256:827d7a5b8454ec19cff2abe0ae6983f15bde4a11c5d5dff4cd74d67ace85a3f2
-            IB_GATEWAY_VERSION=10.45.1g
+            UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1j@sha256:91165c0752ca534c0dad3c40683ae7c2745974d4d277651a90e90411ca609d8d
+            IB_GATEWAY_VERSION=10.45.1j
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Embed buildx provenance so `docker buildx imagetools inspect`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ and the project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`ALERT_AUTO_RESTART` grep-contract token** — `status=adopted`
+  (INFO) or `failed_no_agent` / `failed_jvm_exited` / `failed_login` /
+  `failed_api_timeout` (WARNING), one line per adoption attempt. See
+  [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
+- **`AUTO_RESTART_ADOPT`** (default `yes`) — set to `no` to restore the
+  always-relaunch behaviour; **`AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`**
+  (default `90`) — how long to wait for the self-restarted JVM's agent;
+  and **`AUTO_RESTART_PROBE_SECONDS`** (default `15`) — how long to
+  probe the agent socket when no `restarter.log` was written. The probe
+  plus a 5 s late-log grace is the only added latency, and only on clean
+  exits.
+
+### Changed
+
+- **Upstream base bumped 10.45.1g → 10.45.1j** (still the gnzsnz
+  `:stable` line; digest `sha256:91165c07…`). Three upstream patch
+  releases, and on arm64 it drops 112 MB of dead weight: 10.45.1g's
+  aarch64 image carried `jxbrowser-linux64-8.9.4.jar`, whose
+  `libtoolkit.so` is an x86-64 ELF binary that cannot execute there. It
+  was a side effect of the pre-#397 build, which assembled aarch64
+  images from IBKR's **x64** installer plus a Zulu JRE. Upstream
+  gnzsnz/ib-gateway-docker#397 moved aarch64 to IBKR's native arm
+  installer, first available at 10.45.1h.
+- The arm64 Java runtime changes with it: 10.45.1g used
+  `/usr/local/zulu17…`, while 10.45.1j uses install4j's own JRE
+  registry (`/usr/local/i4j_jres/…`) with no Zulu present. The
+  `release-image.yml` comment describing arm64 as Zulu-based is
+  corrected.
+- CI matrix gains 10.45.1j.
+
 ### Fixed
 
 - **Gateway's own daily auto-restart no longer races the controller
@@ -86,21 +118,7 @@ and the project follows [Semantic Versioning](https://semver.org/).
   - Reported, diagnosed, and prototyped in production by
     @maciejlaska.
 
-### Added
-
-- **`ALERT_AUTO_RESTART` grep-contract token** — `status=adopted`
-  (INFO) or `failed_no_agent` / `failed_jvm_exited` / `failed_login` /
-  `failed_api_timeout` (WARNING), one line per adoption attempt. See
-  [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
-- **`AUTO_RESTART_ADOPT`** (default `yes`) — set to `no` to restore the
-  always-relaunch behaviour; **`AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`**
-  (default `90`) — how long to wait for the self-restarted JVM's agent;
-  and **`AUTO_RESTART_PROBE_SECONDS`** (default `15`) — how long to
-  probe the agent socket when no `restarter.log` was written. The probe
-  plus a 5 s late-log grace is the only added latency, and only on clean
-  exits.
-
-### Fixed (found by that validation)
+### Fixed during validation
 
 - **A dead adopted JVM could look alive indefinitely.** `_AdoptedProcess`
   inferred liveness from `os.kill(pid, 0)` plus `/proc`. Where `/proc`
@@ -180,6 +198,15 @@ and the project follows [Semantic Versioning](https://semver.org/).
   changes, documented by IBC and reported in production by the issue
   reporter. `monitor_loop`'s adopted-exit branch is exercised only
   indirectly, through `_recover_jvm_or_escalate`.
+
+- `tests/integration/gateway_autorestart_drill.py` run against a
+  controller image built on 10.45.1j: **17/17**, so the launcher, agent
+  injection and the issue #23 restart-adoption path all work on the
+  changed arm64 build. The same drill passes on 10.45.1g and on
+  10.50.1e.
+- Login, 2FA and the dialog handlers are unchanged by this bump but are
+  not re-verified against a real account here; they are exercised on
+  10.45.x in production.
 
 ## [0.8.1] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Deeper guides:
 | Requirement | Notes |
 |---|---|
 | Linux `amd64`/`arm64` | Ubuntu 24.04 base tested |
-| IB Gateway 10.x | Release images pin **10.45.1g** (gnzsnz `:stable` line) |
+| IB Gateway 10.x | Release images pin **10.45.1j** (gnzsnz `:stable` line) |
 | Python 3.10+ | Runtime; stdlib only, no pip installs |
 | JDK 17+ | Build time only — runtime uses Gateway's bundled Zulu JRE |
 | `python3`, `matchbox-window-manager` | The only packages added on top of the upstream image |


### PR DESCRIPTION
Same gnzsnz `:stable` line, three patch releases forward, digest `sha256:91165c07…`.

## Why now

Our pin dates from May. Beyond the usual upstream fixes, it is the last release built the old way on arm64, and that turns out to matter.

**The 10.45.1g aarch64 image carries 112 MB that cannot run.** It ships `jxbrowser-linux64-8.9.4.jar`, and the `libtoolkit.so` inside is an x86-64 ELF binary (`e_machine` 0x3e) on an aarch64 image. That is a side effect of the pre-#397 build, which assembled aarch64 images from IBKR's **x64** installer plus a Zulu JRE. Upstream gnzsnz/ib-gateway-docker#397 switched aarch64 to IBKR's native arm installer, first published at 10.45.1h — IBKR published no arm installer at all for 10.45.1g.

Nothing usable is lost: IBKR's arm installer does not carry the browser either way (their 10.45.1j artifacts are 320 MiB for x64 against 206 MiB for arm).

**The arm64 Java runtime changes with it.** 10.45.1g used `/usr/local/zulu17…`; 10.45.1j has no Zulu present and uses install4j's own JRE registry under `/usr/local/i4j_jres`. The `release-image.yml` comment describing arm64 as Zulu-based is corrected here.

## Validation

That runtime change is exactly the sort of thing that breaks launcher and JRE discovery, so this is measured rather than assumed. A controller image built on 10.45.1j passes `tests/integration/gateway_autorestart_drill.py` **17/17** — the real install4j launcher, agent injection into the real Gateway JVM, and the full issue #23 restart-adoption path. The same drill passes on 10.45.1g and on 10.50.1e.

Login, 2FA and the dialog handlers are untouched by this bump and are **not** re-verified against a real account here.

## Notes

- CI matrix gains 10.45.1j. #26 also edits that list (adding 10.50.1e), so whichever merges second needs a one-line rebase.
- Spotted while testing, not fixed here: on 10.45.1j arm64 the installed `.install4j/inst_jre.cfg` still points at the installer's build-time temp directory (`/tmp/setup/…-arm.sh.NNNN.dir/jre`), which does not exist at runtime. Upstream's template only rewrites that file when a `<version>/jre` directory exists, which the arm installer does not produce. Harmless today — the launcher falls back to the `i4j_jres` registry, as the drill shows — but worth reporting upstream.