### PR TITLE
release: v0.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,14 @@ jobs:
 
       - name: Build image against ${{ matrix.upstream }}
         run: |
+          # Pass IB_GATEWAY_VERSION too: since v0.9.0 the Dockerfile's
+          # ARG defaults are the release pin, so without this a matrix
+          # image built on another base would carry the release version
+          # in its label and misreport what it actually contains.
+          MATRIX_UPSTREAM='${{ matrix.upstream }}'
           docker build \
-            --build-arg UPSTREAM_IMAGE=${{ matrix.upstream }} \
+            --build-arg UPSTREAM_IMAGE="$MATRIX_UPSTREAM" \
+            --build-arg IB_GATEWAY_VERSION="${MATRIX_UPSTREAM##*:}" \
             -t ibg-controller:matrix-test .
 
       - name: Container-level module-load smoke test

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -137,16 +137,16 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          # Pin the upstream Gateway base by digest so published releases
-          # don't silently track `:stable`. Bump this in lockstep with a
-          # deliberate Gateway-version upgrade. Multi-arch manifest (amd64
-          # + arm64) as of 10.45.1g, sha256:827d7a5…
-          # IB_GATEWAY_VERSION feeds the com.ibg-controller.ib-gateway-version
-          # image label — keep it in lockstep with the digest pin above so a
-          # `docker inspect` reports the exact bundled Gateway build.
-          build-args: |
-            UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1j@sha256:91165c0752ca534c0dad3c40683ae7c2745974d4d277651a90e90411ca609d8d
-            IB_GATEWAY_VERSION=10.45.1j
+          # Deliberately NO build-args. The digest pin and
+          # IB_GATEWAY_VERSION are the Dockerfile's ARG defaults, which
+          # makes the Dockerfile the single source of truth: a bare
+          # `docker build .` reproduces exactly what this workflow
+          # publishes. Bump the pin there, not here.
+          #
+          # Why it matters (2026-09-07 pre-release spike): while the
+          # default was the moving `:stable` tag, a bare build silently
+          # used a stale cached base and labelled it `unknown`, so a
+          # maintainer could "validate" a Gateway version that never ran.
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Embed buildx provenance so `docker buildx imagetools inspect`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.9.0] - 2026-09-07
 
 ### Added
 
@@ -50,6 +50,26 @@ and the project follows [Semantic Versioning](https://semver.org/).
   the recipe was simply undocumented.
 
 ### Fixed
+
+- **A bare `docker build .` no longer silently builds the wrong base.**
+  `UPSTREAM_IMAGE` defaulted to the moving `:stable` tag, so a local
+  build picked up whatever `:stable` sat in the Docker cache — in the
+  2026-09-07 pre-release spike, a five-month-old base — and labelled it
+  `IB_GATEWAY_VERSION=unknown`. A maintainer could therefore "validate"
+  a Gateway version that never ran. The Dockerfile's ARG defaults are
+  now the release pin itself, making the Dockerfile the single source of
+  truth: `release-image.yml` passes no build args and inherits them, and
+  a bare build reproduces the published image. The CI matrix passes
+  `IB_GATEWAY_VERSION` alongside its `UPSTREAM_IMAGE` override so
+  matrix images still report what they actually contain.
+- **Paper logins no longer emit a spurious `ERROR`.** `handle_login`
+  probed `"Log In"` before `"Paper Log In"`, so every paper login logged
+  `agent CLICK 'Log In': ERR not_found` at ERROR level immediately
+  before succeeding — enough to false-positive an "ERROR means page
+  someone" rule. The mode's expected label is now tried first, and the
+  probe uses a new `quiet=` argument on `agent_click` that demotes an
+  expected miss to DEBUG. Real failures stay at ERROR.
+
 
 - **Gateway's own daily auto-restart no longer races the controller
   into a cold login (issue #23).** With `AUTO_RESTART_TIME` set,
@@ -143,6 +163,26 @@ and the project follows [Semantic Versioning](https://semver.org/).
   tests below, not by the mocked unit tests.
 
 ### Validation
+
+- **Live-spiked on a real dual-mode account 2026-09-07 (Gateway
+  10.45.1j, arm64), the maintainer spike `CONTRIBUTING.md` requires
+  before release.** Both modes reached `MONITORING` (live 18:48:41,
+  paper 18:49:29), API ports 4001/4002 open, `/health` healthy for
+  both, and **zero `ALERT_*` tokens of any kind**. The previously
+  unverified surface all passed on the new base: agent injected into
+  install4j's JRE, login dialog discovered, 2FA method prompt matched
+  and TOTP typed, disclaimers dismissed. The outgoing container
+  released both IBKR session slots cleanly (`ALERT_CLEAN_LOGOUT
+  status=succeeded`) before the swap.
+- install4j's bundled JRE on 10.45.1j is Zulu 17.0.17, so the agent's
+  `--release 17` bytecode still matches the runtime it loads into.
+- Still pending at release time: the first `AUTO_LOGOFF_TIME` cycle on
+  10.45.1j. Expect one new INFO line per mode (`AUTORESTART: no fresh
+  install4j restarter.log; probing …`) and ~20 s of added detection
+  delay before the normal in-place restart. No `ALERT_AUTO_RESTART`
+  should appear: with `AUTO_RESTART_TIME` unset, install4j's restarter
+  never runs.
+
 
 - New unit coverage: `_install4j_restarter_age` (fresh / stale /
   missing / future-dated log, unknown launcher, discovery fallback),

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,16 @@
 # (agent jar + Python controller) and swaps upstream's run.sh for the
 # controller-aware variant shipped alongside.
 #
-# UPSTREAM_IMAGE defaults to the :stable moving tag for low-friction
-# local builds. Production consumers should pin a digest via --build-arg
-# so rebuilds are reproducible, e.g.:
+# UPSTREAM_IMAGE defaults to the SAME digest-pinned base the release
+# workflow publishes, so a bare `docker build .` reproduces the shipped
+# image. This is the single source of truth for the pin — release-image.yml
+# passes no build args and inherits these defaults. Bump both ARGs together.
 #
-#   docker build -t ibg-controller:local \
-#     --build-arg UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1c@sha256:... .
+# It used to default to the moving `:stable` tag, which was a trap: a bare
+# build silently picked up whatever `:stable` happened to be in the local
+# cache (a five-month-old base, in one 2026-09-07 pre-release spike) and
+# labelled it `unknown`, so a maintainer could "validate" a version that
+# never ran.
 #
 # Any gnzsnz base works, including their `latest` channel if you want a
 # newer Gateway than the stable line carries (issue #24). This layer is
@@ -27,13 +31,13 @@
 # dist/ with the agent jar and the controller .py, then `docker build .`
 # from the same directory.
 
-ARG UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:stable
+ARG UPSTREAM_IMAGE=ghcr.io/gnzsnz/ib-gateway:10.45.1j@sha256:91165c0752ca534c0dad3c40683ae7c2745974d4d277651a90e90411ca609d8d
 FROM ${UPSTREAM_IMAGE}
 
 # Re-declare post-FROM so they're in scope for the LABEL below (a build ARG
 # declared before FROM is only visible to the FROM instruction itself).
 ARG UPSTREAM_IMAGE
-ARG IB_GATEWAY_VERSION=unknown
+ARG IB_GATEWAY_VERSION=10.45.1j
 
 # Self-describing image: record the bundled IB Gateway version and the exact
 # upstream base so `docker inspect` (and the GHCR page) report them without

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Version is overridable on the command line:
 #   make release VERSION=0.2.0
 
-VERSION          ?= 0.8.1
+VERSION          ?= 0.9.0
 NAME             := ibg-controller
 DIST             := dist
 AGENT_SRC        := agent/GatewayInputAgent.java

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Deeper guides:
 | Linux `amd64`/`arm64` | Ubuntu 24.04 base tested |
 | IB Gateway 10.x | Release images pin **10.45.1j** (gnzsnz `:stable` line) |
 | Python 3.10+ | Runtime; stdlib only, no pip installs |
-| JDK 17+ | Build time only — runtime uses Gateway's bundled Zulu JRE |
+| JDK 17+ | Build time only — runtime uses the JRE bundled with Gateway |
 | `python3`, `matchbox-window-manager` | The only packages added on top of the upstream image |
 
 ## What works

--- a/agent/GatewayInputAgent.java
+++ b/agent/GatewayInputAgent.java
@@ -79,8 +79,9 @@ import javax.swing.tree.TreePath;
  *     invokeAndWait.
  *
  * External dependencies: only the JDK standard library + the Swing
- * and accessibility APIs bundled with Gateway's Zulu JRE. No
- * transitive jars.
+ * and accessibility APIs bundled with Gateway's own JRE (Zulu 17 on
+ * Gateway 10.45.x, Zulu 25 on 10.50.x — the agent targets release 17
+ * bytecode, which both run). No transitive jars.
  */
 public class GatewayInputAgent {
 

--- a/docs/FROM_IBC.md
+++ b/docs/FROM_IBC.md
@@ -166,9 +166,11 @@ make                         # builds agent jar + stages controller
 docker build -t ibg-controller:local .
 ```
 
-The shipped `Dockerfile` extends `ghcr.io/gnzsnz/ib-gateway:stable`.
-For reproducible builds, pin to a digest via `--build-arg
-UPSTREAM_IMAGE=...@sha256:...`.
+The shipped `Dockerfile` defaults to the same digest-pinned base the
+release images use, so a bare `docker build .` reproduces what we
+publish. Override `--build-arg UPSTREAM_IMAGE=...` only to build
+against a different Gateway; if you do, pass `IB_GATEWAY_VERSION` too
+so the image label reports what it actually contains.
 
 Any gnzsnz base works. To build against their `latest` channel instead
 of `stable` — a newer Gateway line, e.g. for the in-app browser the

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -76,7 +76,7 @@ Only versions that need operator attention are listed. If a version
 isn't listed, it contained only additive changes that don't require
 anything from you.
 
-### Unreleased
+### v0.9.0
 
 - **If you set `AUTO_RESTART_TIME`, the controller no longer relaunches
   Gateway after Gateway's own daily restart (issue #23).** It detects
@@ -106,6 +106,18 @@ anything from you.
     `AUTORESTART:` lines above it.
   - Pure Python, no agent-jar change — pull the new image or, if you
     build from source, `make`.
+- **The upstream Gateway base moved 10.45.1g → 10.45.1j** (still the
+  gnzsnz `:stable` line). Live-validated on a real dual-mode account:
+  both modes reach `MONITORING`, login and 2FA drive cleanly, no
+  `ALERT_*` tokens. On arm64 the image also sheds 112 MB of x86-64
+  browser payload that could never execute there.
+- **If you build the image yourself, `docker build .` now produces the
+  release base by default.** `UPSTREAM_IMAGE` previously defaulted to
+  the moving `:stable` tag, which meant a bare build could silently use
+  a stale cached base and label it `unknown`. Override
+  `--build-arg UPSTREAM_IMAGE=` to build against a different Gateway,
+  and pass `IB_GATEWAY_VERSION=` with it so the image label stays
+  honest.
   - If you don't set `AUTO_RESTART_TIME`, Gateway never restarts
     itself, so neither signal fires and every exit takes the existing
     recovery path — apart from the added detection delay above.

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -49,7 +49,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from zoneinfo import ZoneInfo
 
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 
 # Wall-clock timestamp recorded when the controller module loads. Reported
 # by the /health endpoint as `uptime_seconds` so monitoring can spot a
@@ -457,16 +457,33 @@ def agent_gettext(name):
     return None
 
 
-def agent_click(name):
-    """Click an AbstractButton by accessible name. Returns True on success."""
+def _login_button_labels(mode=None):
+    """Return ``(expected, fallback)`` Log In button labels for a trading
+    mode. Gateway renames the button: "Log In" on live, "Paper Log In"
+    on paper. Probing the expected one first keeps the routine case off
+    the ERROR log (see the call site in ``handle_login``)."""
+    if (mode if mode is not None else TRADING_MODE) == "paper":
+        return ("Paper Log In", "Log In")
+    return ("Log In", "Paper Log In")
+
+
+def agent_click(name, quiet=False):
+    """Click an AbstractButton by accessible name. Returns True on success.
+
+    ``quiet=True`` demotes a failed click to DEBUG. Use it only where a
+    miss is an expected outcome the caller handles — probing a button
+    whose label varies, for instance — so that real failures stay at
+    ERROR and log-scraping alert rules don't fire on routine probes.
+    """
+    level = log.debug if quiet else log.error
     try:
         resp = _agent_request(f"CLICK {name}")
     except Exception as e:
-        log.error(f"agent CLICK {name!r}: {type(e).__name__}: {e}")
+        level(f"agent CLICK {name!r}: {type(e).__name__}: {e}")
         return False
     if resp.startswith("OK"):
         return True
-    log.error(f"agent CLICK {name!r}: {resp}")
+    level(f"agent CLICK {name!r}: {resp}")
     return False
 
 
@@ -1197,7 +1214,13 @@ def handle_login(app):
     # Log In button. Gateway renames the button based on trading mode:
     #   Live Trading  → "Log In"
     #   Paper Trading → "Paper Log In"
-    if not (agent_click("Log In") or agent_click("Paper Log In")):
+    # Try the label this mode is expected to use first, and probe quietly:
+    # before v0.9.0 every paper login emitted a spurious
+    # `agent CLICK 'Log In': ERR not_found` at ERROR level immediately
+    # before succeeding on the second label, which false-positived any
+    # "ERROR means page someone" rule.
+    expected, fallback = _login_button_labels()
+    if not (agent_click(expected, quiet=True) or agent_click(fallback)):
         log.error("Log In / Paper Log In button click failed via agent")
         # Diagnostic: dump the login window's component tree via the agent.
         # This is an ERROR-level (always-emitted) dump of the login frame,

--- a/tests/test_pure_logic.py
+++ b/tests/test_pure_logic.py
@@ -2414,6 +2414,70 @@ def _sleeper():
     return subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
 
 
+class TestLoginButtonLabels(unittest.TestCase):
+    """Gateway renames the Log In button per mode. Probing the wrong one
+    first made every paper login emit a spurious ERROR-level
+    `agent CLICK 'Log In': ERR not_found` immediately before succeeding
+    — harmless, but it false-positives any "ERROR means page someone"
+    rule. Found in the v0.9.0 pre-release spike."""
+
+    def test_paper_tries_paper_label_first(self):
+        self.assertEqual(gc._login_button_labels("paper"),
+                         ("Paper Log In", "Log In"))
+
+    def test_live_tries_plain_label_first(self):
+        self.assertEqual(gc._login_button_labels("live"),
+                         ("Log In", "Paper Log In"))
+
+    def test_both_labels_always_offered(self):
+        for mode in ("paper", "live"):
+            self.assertEqual(set(gc._login_button_labels(mode)),
+                             {"Log In", "Paper Log In"})
+
+    def test_defaults_to_module_trading_mode(self):
+        with patch.object(gc, "TRADING_MODE", "paper"):
+            self.assertEqual(gc._login_button_labels()[0], "Paper Log In")
+        with patch.object(gc, "TRADING_MODE", "live"):
+            self.assertEqual(gc._login_button_labels()[0], "Log In")
+
+
+class TestAgentClickQuiet(unittest.TestCase):
+    """quiet=True demotes an expected miss to DEBUG so routine probes
+    don't look like failures; real failures must stay at ERROR."""
+
+    def test_failure_logs_error_by_default(self):
+        with patch.object(gc, "_agent_request", return_value="ERR not_found"), \
+             patch.object(gc.log, "error") as err, \
+             patch.object(gc.log, "debug") as dbg:
+            self.assertFalse(gc.agent_click("Log In"))
+            err.assert_called_once()
+            dbg.assert_not_called()
+
+    def test_quiet_failure_logs_debug(self):
+        with patch.object(gc, "_agent_request", return_value="ERR not_found"), \
+             patch.object(gc.log, "error") as err, \
+             patch.object(gc.log, "debug") as dbg:
+            self.assertFalse(gc.agent_click("Log In", quiet=True))
+            err.assert_not_called()
+            dbg.assert_called_once()
+
+    def test_quiet_exception_also_demoted(self):
+        with patch.object(gc, "_agent_request", side_effect=OSError("boom")), \
+             patch.object(gc.log, "error") as err, \
+             patch.object(gc.log, "debug") as dbg:
+            self.assertFalse(gc.agent_click("X", quiet=True))
+            err.assert_not_called()
+            dbg.assert_called_once()
+
+    def test_success_never_logs(self):
+        with patch.object(gc, "_agent_request", return_value="OK"), \
+             patch.object(gc.log, "error") as err, \
+             patch.object(gc.log, "debug") as dbg:
+            self.assertTrue(gc.agent_click("Log In", quiet=True))
+            err.assert_not_called()
+            dbg.assert_not_called()
+
+
 class TestInstall4jRestarterAge(unittest.TestCase):
     """_install4j_restarter_age is the only trigger for self-restart
     detection: seconds since install4j last wrote


### PR DESCRIPTION
Cuts 0.9.0 from the three merges on `main` (issue #23 auto-restart adoption, the 10.45.1j pin bump, 10.50 CI coverage) plus the two defects the pre-release spike surfaced.

**Minor, not patch:** the recovery path changes by default, three env vars appear (`AUTO_RESTART_ADOPT`, `AUTO_RESTART_ADOPT_TIMEOUT_SECONDS`, `AUTO_RESTART_PROBE_SECONDS`) and so does a new grep-contract token (`ALERT_AUTO_RESTART`).

## Spike results

Live-validated on a real dual-mode account against Gateway 10.45.1j (arm64) — the maintainer spike `CONTRIBUTING.md` requires before release:

- Both modes reached `MONITORING` (live 18:48:41, paper 18:49:29).
- API ports 4001/4002 open; `/health` healthy for both.
- **Zero `ALERT_*` tokens of any kind.**
- The surface the drills couldn't reach all passed on the new base: agent injected into install4j's JRE, login dialog discovered, 2FA method prompt matched and TOTP typed, disclaimers dismissed.
- The outgoing container released both IBKR session slots cleanly before the swap.

## Two defects the spike found, fixed here

**A bare `docker build .` built the wrong base.** `UPSTREAM_IMAGE` defaulted to the moving `:stable` tag, so a local build used whatever `:stable` sat in the Docker cache — a five-month-old base during the spike — and labelled it `unknown`. A maintainer could therefore "validate" a Gateway version that never ran; only the label gate caught it. The Dockerfile's ARG defaults are now the release pin itself, making the Dockerfile the single source of truth: `release-image.yml` passes no build args and inherits them. Verified: a bare build now reports `10.45.1j` in both the version label and the base name. The CI matrix passes `IB_GATEWAY_VERSION` with its `UPSTREAM_IMAGE` override so matrix images don't misreport what they contain.

**Every paper login emitted a spurious `ERROR`.** `handle_login` probed `"Log In"` before `"Paper Log In"`, so paper logged `agent CLICK 'Log In': ERR not_found` at ERROR level immediately before succeeding — enough to false-positive an "ERROR means page someone" rule. The mode's expected label is now tried first via a `_login_button_labels` helper, and the probe uses a new `quiet=` argument on `agent_click` that demotes an expected miss to DEBUG. Real failures stay at ERROR.

Eight new tests cover both. 322 passing.

## Not treated as a defect

The spike flagged Zulu references in `README.md` and the agent source as stale. They were accurate — install4j's bundled JRE on 10.45.1j is Zulu 17.0.17, which is also why the agent's `--release 17` bytecode still matches. They're made version-agnostic here rather than corrected, since 10.50.x bundles Zulu 25.

## Before tagging

One spike item is still pending: the first `AUTO_LOGOFF_TIME` cycle on 10.45.1j, due 17:01 ET. Expect one new INFO line per mode (`AUTORESTART: no fresh install4j restarter.log; probing …`) and ~20 s of added detection delay before the normal in-place restart; no `ALERT_AUTO_RESTART` should appear, since install4j's restarter never runs with `AUTO_RESTART_TIME` unset.

Merging this does not publish anything. Pushing the `v0.9.0` tag is what cuts the GitHub release and the signed image, and moves `:latest`.