### PR TITLE
fix(config): verify the Lock and Exit schedule actually stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to `ibg-controller` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **A Lock and Exit schedule that Gateway silently drops is now
+  reported instead of claimed as applied.** The controller wrote
+  `AUTO_LOGOFF_TIME` / `AUTO_RESTART_TIME`, saw
+  `agent_settext_by_label` return success, and logged "Post-login
+  config applied". That only means the widget accepted the write. On
+  2026-09-07 a production box logged `Setting Auto Log Off Time =
+  05:01 PM`, then ran 26 hours straight through that boundary without
+  logging off — and the same non-firing had been observed a month
+  earlier on v0.8.0, so it is long-standing rather than a regression.
+  After OK the controller now re-opens Configure → Settings, re-selects
+  Lock and Exit, and reads the value back, closing with **Cancel** so
+  the check itself commits nothing.
+  - Verified value: logged as confirmed.
+  - Value gone: new grep-contract token `ALERT_CONFIG_NOT_APPLIED`
+    (ERROR) naming the setting, the env var and the requested value.
+    Worth paging on — the session is healthy and logged in, which is
+    precisely why a silently missing daily schedule goes unnoticed.
+  - Dialog unreadable: a WARNING saying *unverified*, never reported as
+    a failure. Verification is best-effort and never fails the login.
+  - The old "Post-login config applied and dialog closed" line now
+    reads "committed", since applied was the claim that wasn't earned.
+- Note for anyone depending on Gateway's daily logoff: if you see this
+  token, treat an external scheduled container restart as the reliable
+  substitute rather than Gateway's own scheduler.
+
 ## [0.9.0] - 2026-09-07
 
 ### Added

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -219,6 +219,45 @@ took longer than the configured delay — consider tuning
 INFO-tier visibility dashboards, no debounce — frequency itself is
 useful signal.
 
+### `ALERT_CONFIG_NOT_APPLIED`
+
+```
+ALERT_CONFIG_NOT_APPLIED mode=live setting="Set Auto Log Off Time (HH:MM)" env_var=AUTO_LOGOFF_TIME requested="05:01 PM" reason="Gateway did not retain the value after OK; the schedule will not fire"
+```
+
+**When fired**: the controller wrote a Lock and Exit schedule
+(`AUTO_LOGOFF_TIME` or `AUTO_RESTART_TIME`), clicked OK, then re-opened
+the dialog and found the value gone. The write was accepted and the
+schedule still will not happen.
+
+**What it means**: any automation you have built on that daily boundary
+— a restart, a reconnect, a downstream job — will not be triggered by
+Gateway. This is not a controller crash; the session is logged in and
+healthy, which is exactly why it is worth paging on: everything looks
+fine while a scheduled event silently never occurs.
+
+**Why the check exists**: `agent_settext_by_label` returning success
+only means the write was accepted by the widget. On 2026-09-07 a
+production box logged `Setting Auto Log Off Time = 05:01 PM` and
+`Post-login config applied`, then ran 26 hours straight through the
+configured boundary without ever logging off. Only a read-back after
+the commit distinguishes the two cases.
+
+**What the operator should do**: check the value in Gateway's UI over
+VNC. If Gateway is showing the *other* Lock and Exit field (it offers
+either Auto Log Off Time or Auto Restart Time, never both, depending on
+account state) then set the matching env var instead. If Gateway shows
+your value but still does not act on it, the schedule is not usable on
+that account and an external scheduled restart is the reliable
+substitute.
+
+**Log level**: `ERROR`. Page on it once per container start at most —
+it is emitted only on the post-login config pass.
+
+**Related**: a `Could not verify …` WARNING is emitted instead when the
+dialog could not be re-opened or read at all. That means unverified,
+not failed; do not page on it.
+
 ### `ALERT_AUTO_RESTART`
 
 ```
@@ -790,7 +829,8 @@ four additional `ALERT_CLEAN_LOGOUT` `status=` values
 (`safe_no_session`, `zombie_slot_cannot_release`,
 `cancelled_pending_2fa`, `failed_cancel_2fa`) in v0.5.9, and
 `ALERT_AUTO_RESTART` (INFO on `status=adopted`, WARNING on the
-`failed_*` statuses) with the issue #23 fix — all under the same
+`failed_*` statuses) with the issue #23 fix, and
+`ALERT_CONFIG_NOT_APPLIED` (ERROR) in v0.9.1 — all under the same
 stability contract. Breaking changes will be called out in
 the CHANGELOG and accompany a minor version bump. Adding new fields
 to `/health`, new `ALERT_*` tokens, or new `status=` values to

--- a/gateway_controller.py
+++ b/gateway_controller.py
@@ -2352,6 +2352,65 @@ def _coerce_yes_no(val):
     return None
 
 
+def _lock_exit_time_visible(expected):
+    """True if ``expected`` appears in the Lock and Exit panel right now.
+
+    Reads the live component dump of the already-open config dialog, so
+    it costs one agent round-trip and needs no new agent command.
+    Returns None when the panel can't be read at all, which the caller
+    reports as "unverified" rather than "wrong".
+    """
+    dump = agent_window(CONFIG_WINDOW_TITLE_SUBSTR)
+    if not dump or not dump.startswith("OK"):
+        return None
+    # Gateway renders the time into a text field; a substring match is
+    # enough and survives the widget being a JSpinner editor, a
+    # formatted field, or a plain JTextField.
+    return expected.strip() in dump
+
+
+def _verify_lock_exit_time_persisted(label, expected):
+    """Re-open Configure → Settings after OK and confirm the Lock and Exit
+    time really stuck. Returns True/False, or None if it couldn't be
+    checked.
+
+    Why re-open rather than trust the write: on 2026-09-07 a production
+    box logged "Setting Auto Log Off Time = 05:01 PM" followed by
+    "Post-login config applied and dialog closed", and then ran 26 hours
+    straight through the configured boundary without ever logging off.
+    ``agent_settext_by_label`` reported success, so the in-dialog write
+    is not evidence that Gateway accepted or kept the value. Only a
+    read-back after the commit is.
+
+    Failure here is never fatal: the session is already logged in and
+    usable, so the worst case is that we say the setting is unverified
+    instead of silently claiming it was applied.
+    """
+    try:
+        if not _config_open():
+            log.warning("  Could not re-open config dialog to verify "
+                        f"{label!r}; treating as unverified")
+            return None
+        try:
+            if not agent_jtree_select_path(CONFIG_WINDOW_TITLE_SUBSTR,
+                                           "Lock and Exit"):
+                log.warning("  Could not re-select Lock and Exit to verify "
+                            f"{label!r}; treating as unverified")
+                return None
+            time.sleep(1.0)  # same panel-render settle as the write path
+            return _lock_exit_time_visible(expected)
+        finally:
+            # Cancel, never OK: verification must not itself commit
+            # anything, and an unchanged form should leave no side effect.
+            if not _config_close("Cancel"):
+                log.warning("  Could not close the verification dialog with "
+                            "Cancel — check for a stray config window")
+    except Exception as e:
+        log.warning(f"  Verification of {label!r} raised "
+                    f"{type(e).__name__}: {e}; treating as unverified")
+        return None
+
+
 def handle_post_login_config():
     """Drive Gateway's Configure → Settings dialog to apply env-var
     overrides for the IBC-compatible API config knobs.
@@ -2431,6 +2490,9 @@ def handle_post_login_config():
         return False
 
     changed = False
+    # (label, value, env var) of the Lock and Exit time we wrote, if any.
+    # Verified after OK — see _verify_lock_exit_time_persisted.
+    lock_exit_written = None
 
     if wanted_api_tab:
         log.info("  Navigating to API → Settings")
@@ -2474,6 +2536,8 @@ def handle_post_login_config():
                 if agent_settext_by_label(CONFIG_WINDOW_TITLE_SUBSTR,
                                           logoff_label, auto_logoff_time):
                     changed = True
+                    lock_exit_written = (logoff_label, auto_logoff_time,
+                                         "AUTO_LOGOFF_TIME")
                 else:
                     # Gateway may be in autorestart-mode for this account —
                     # the field is labeled "Set Auto Restart Time" instead.
@@ -2486,6 +2550,8 @@ def handle_post_login_config():
                 if agent_settext_by_label(CONFIG_WINDOW_TITLE_SUBSTR,
                                           restart_label, auto_restart_time):
                     changed = True
+                    lock_exit_written = (restart_label, auto_restart_time,
+                                         "AUTO_RESTART_TIME")
                 else:
                     log.warning("  Failed to set Auto Restart Time — "
                                 "Gateway is showing 'Set Auto Log Off Time' "
@@ -2497,7 +2563,27 @@ def handle_post_login_config():
         if not _config_close("OK"):
             log.warning("Could not click OK to commit config changes")
             return False
-        log.info("Post-login config applied and dialog closed")
+        log.info("Post-login config committed; dialog closed")
+        if lock_exit_written is not None:
+            label, value, env_var = lock_exit_written
+            time.sleep(1.0)  # let the dialog fully dispose before re-opening
+            verified = _verify_lock_exit_time_persisted(label, value)
+            if verified is True:
+                log.info(f"  Verified: {label} reads back as {value!r}")
+            elif verified is False:
+                # Stable grep token: an operator who set a schedule needs
+                # to know it will not happen. See docs/OBSERVABILITY.md.
+                log.error(
+                    f"ALERT_CONFIG_NOT_APPLIED mode={TRADING_MODE} "
+                    f"setting=\"{label}\" env_var={env_var} "
+                    f"requested=\"{value}\" "
+                    f"reason=\"Gateway did not retain the value after OK; "
+                    f"the schedule will not fire\"")
+            else:
+                log.warning(
+                    f"  Could not verify {label} — it may or may not have "
+                    "been applied. Confirm in the Gateway UI if you depend "
+                    "on the schedule.")
     else:
         # Nothing was actually changed — use Cancel to avoid any
         # side-effect of OK that might otherwise fire even for an

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -579,5 +579,79 @@ class TestAutoRestartAdoptionEndToEnd(unittest.TestCase):
         self.assertLess(elapsed, 12, "waited on an already-handled restart")
 
 
+class TestLockExitTimeVerification(unittest.TestCase):
+    """A production box logged `Setting Auto Log Off Time = 05:01 PM`
+    and `Post-login config applied`, then ran 26 hours straight through
+    that boundary without logging off (2026-09-07, and the same
+    non-firing was seen a month earlier on v0.8.0). `agent_settext_by_label`
+    returning True says the write was accepted, not that Gateway kept
+    it — so the value is now read back after OK."""
+
+    def setUp(self):
+        for name in ("_config_open", "_config_close", "agent_jtree_select_path",
+                     "agent_window", "time"):
+            self.assertTrue(hasattr(gc, name), name)
+
+    def _patches(self, dump, open_ok=True, tree_ok=True, close_ok=True):
+        return [
+            patch.object(gc, "_config_open", return_value=open_ok),
+            patch.object(gc, "agent_jtree_select_path", return_value=tree_ok),
+            patch.object(gc, "_config_close", return_value=close_ok),
+            patch.object(gc, "agent_window", return_value=dump),
+            patch.object(gc.time, "sleep"),
+        ]
+
+    def _run(self, *a, **kw):
+        ps = self._patches(*a, **kw)
+        for p in ps:
+            p.start()
+            self.addCleanup(p.stop)
+        return gc._verify_lock_exit_time_persisted(
+            "Set Auto Log Off Time (HH:MM)", "05:01 PM")
+
+    def test_value_present_verifies(self):
+        self.assertIs(self._run("OK\nJTextField: 05:01 PM\nEND\n"), True)
+
+    def test_value_absent_fails_verification(self):
+        # The real production symptom: dialog reads back empty.
+        self.assertIs(self._run("OK\nJTextField: \nEND\n"), False)
+
+    def test_different_value_fails_verification(self):
+        self.assertIs(self._run("OK\nJTextField: 11:59 PM\nEND\n"), False)
+
+    def test_unreadable_dialog_is_unverified_not_wrong(self):
+        # None means "couldn't check" and must not be reported as a
+        # failed setting.
+        self.assertIsNone(self._run(""))
+        self.assertIsNone(self._run("ERR no_such_window"))
+
+    def test_cannot_reopen_is_unverified(self):
+        self.assertIsNone(self._run("OK\nJTextField: 05:01 PM\nEND\n",
+                                    open_ok=False))
+
+    def test_cannot_select_panel_is_unverified(self):
+        self.assertIsNone(self._run("OK\nJTextField: 05:01 PM\nEND\n",
+                                    tree_ok=False))
+
+    def test_verification_never_commits(self):
+        """Verification must close with Cancel, never OK — otherwise the
+        check itself could apply a half-filled form."""
+        ps = self._patches("OK\nJTextField: 05:01 PM\nEND\n")
+        for p in ps:
+            p.start()
+            self.addCleanup(p.stop)
+        gc._verify_lock_exit_time_persisted("Set Auto Log Off Time (HH:MM)",
+                                            "05:01 PM")
+        gc._config_close.assert_called_once_with("Cancel")
+
+    def test_exception_is_swallowed_as_unverified(self):
+        with patch.object(gc, "_config_open", side_effect=RuntimeError("boom")):
+            self.assertIsNone(gc._verify_lock_exit_time_persisted("L", "V"))
+
+    def test_visible_helper_tolerates_missing_dump(self):
+        with patch.object(gc, "agent_window", return_value=None):
+            self.assertIsNone(gc._lock_exit_time_visible("05:01 PM"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Found by the v0.9.0 production spike.

## The bug

The controller wrote `AUTO_LOGOFF_TIME` / `AUTO_RESTART_TIME`, saw `agent_settext_by_label` return success, and logged **"Post-login config applied"**. That only ever meant the widget accepted the write.

On 2026-09-07 a production box logged `Setting Auto Log Off Time = 05:01 PM` and `Post-login config applied`, then ran **26 hours straight through that boundary** without logging off. The same non-firing was seen a month earlier on v0.8.0, so it is long-standing, not a v0.9.0 regression.

It matters beyond cosmetics: a deployment can build a daily restart, a reconnect, or a downstream job on a boundary Gateway never honours — and nothing in the logs suggests anything is wrong. That is exactly the failure shape this project has been burned by before (the SETTEXT fallback in #7/#20, and the build-label trap in v0.9.0), where success is reported without being earned.

## The fix

After OK, re-open Configure → Settings, re-select Lock and Exit, read the value back, and close with **Cancel** so the check itself commits nothing.

| read-back | result |
|---|---|
| value present | logged as verified |
| value gone | `ALERT_CONFIG_NOT_APPLIED` (ERROR), naming setting, env var, requested value |
| dialog unreadable | WARNING saying *unverified* — never reported as failed |

Verification is best-effort and never fails the login. A re-open that doesn't work, a panel that won't select, or any exception all fall through to "unverified". The "applied" log line now reads "committed".

## What it deliberately does not do

It does not try to make Gateway honour a schedule it is dropping — we don't yet know whether Gateway rejects the value, needs a mode selected alongside it, or ignores it for this account class. Where the token fires, an external scheduled container restart is the reliable substitute, and the docs say so.

## Tests

Nine new: verified / absent / mismatched / unreadable / cannot re-open / cannot select / exception-swallowed, plus one asserting the check closes with Cancel rather than OK. **331 passing.**

`ALERT_CONFIG_NOT_APPLIED` is documented in `docs/OBSERVABILITY.md` with triage steps and added to the stability contract.